### PR TITLE
Specify the service name for ssh

### DIFF
--- a/openssh/init.sls
+++ b/openssh/init.sls
@@ -6,6 +6,7 @@ openssh:
     {% endif %}
   service.running:
     - enable: True
+    - name: ssh
     - require:
       - pkg: openssh
       - file: sshd_banner


### PR DESCRIPTION
Current code was asking for service 'openssh' which does not exist. It is 'ssh'. Specifying a name in the `service.running` block fixes this.
