### PR TITLE
change watch_in to watch under service to avoid: ssh not part of the sta...

### DIFF
--- a/openssh/config.sls
+++ b/openssh/config.sls
@@ -7,6 +7,6 @@ sshd_config:
   file.managed:
     - name: {{ openssh.sshd_config }}
     - source: {{ openssh.sshd_config_src }}
-    - watch_in:
+    - watch:
       - service: {{ openssh.service }}
 


### PR DESCRIPTION
change watch_in to watch under service to avoid: "ssh not part of the state" issue in ubuntu 12.04
