### PR TITLE
Add FreeBSD compatibility

### DIFF
--- a/openssh/init.sls
+++ b/openssh/init.sls
@@ -1,10 +1,14 @@
 {% from "openssh/map.jinja" import openssh with context %}
 
 openssh:
+  {% if openssh.server is defined %}
   pkg.installed:
     - name: {{ openssh.server }}
+  {% endif %}
   service.running:
     - enable: True
     - name: {{ openssh.service }}
+  {% if openssh.server is defined %}
     - require:
       - pkg: {{ openssh.server }}
+  {% endif %}

--- a/openssh/map.jinja
+++ b/openssh/map.jinja
@@ -17,4 +17,11 @@
         'banner': '/etc/ssh/banner',
         'banner_src': 'salt://openssh/files/banner',
     },
+	'FreeBSD': {
+		'service': 'sshd',
+		'sshd_config': '/etc/ssh/sshd_config',
+		'sshd_config_src': 'salt://openssh/files/sshd_config',
+		'banner': '/etc/ssh/banner',
+		'banner_src': 'salt://openssh/files/banner',
+	}
 }, merge=salt['pillar.get']('openssh:lookup')) %}


### PR DESCRIPTION
There's no server or client package defined here as FreeBSD ships with its own version of OpenSSH in the base system.

However, there is another version in pkg (FreeBSD's package command, not salt's abstraction layer). I believe anyone who wants this version on FreeBSD could trivially override the map, adding the server/client keys and it should just work.
