### PR TITLE
Remove reference to root group

### DIFF
--- a/openssh/config.sls
+++ b/openssh/config.sls
@@ -9,7 +9,6 @@ sshd_config:
     - source: {{ openssh.sshd_config_src }}
     - template: jinja
     - user: root
-    - group: root
     - mode: 644
     - watch_in:
       - service: openssh


### PR DESCRIPTION
This formula fails to manage the config on a system where there is no `root` group.

By not specifying it, root user's group should be used, whether that's `root`, `wheel`, `admin`, etc.

Seems much simpler than having another point of configuration.
