### PR TITLE
Fix jinja spacing mistake for unknown options

### DIFF
--- a/openssh/files/sshd_config
+++ b/openssh/files/sshd_config
@@ -140,7 +140,7 @@
 {%- for keyword in sshd_config.keys() %}
   {#- Matches have to be at the bottem and should be handled differently -#}
   {%- if not keyword in processed_options and keyword != 'matches' -%}
-{#- send a blank default as it doesn't matter -#} 
+{#- send a blank default as it doesn't matter #}
 {{ render_option(keyword, '') }}
   {%- endif -%}
 {%- endfor %}


### PR DESCRIPTION
When specifying multiple unknown ssh options, they would all appear on
the same line.

For example, specifying:

```
ClientAliveInterval 30
ClientAliveCountMax 99999
```

Would render as:

```
ClientAliveInterval 30ClientAliveCountMax 99999
```
