### PR TITLE
Refactor auth.sls to allow more keys for one user

### DIFF
--- a/openssh/auth.sls
+++ b/openssh/auth.sls
@@ -1,15 +1,18 @@
-include:
-  - openssh
-{%- from "openssh/map.jinja" import openssh with context -%}
-{%- set openssh_pillar = pillar.get('openssh', {}) -%}
-{%- set auth = openssh_pillar.get('auth', {}) -%}
-{%- for user,keys in auth.items() -%}
-  {%- for key in keys -%}
-    {% if 'present' in key and key['present'] %}
+{%- macro print_name(identifier, key) -%}
+{%- if 'name' in key  %}
 {{ key['name'] }}:
-  ssh_auth.present:
-    - user: {{ user }}
-      {%- if 'source' in key %}
+{%- else %}
+{{ identifier }}:
+{%- endif %}
+{%- endmacro -%}
+
+{%- macro print_ssh_auth(identifier, key) -%}
+      {%- if 'user' in key  %}
+    - user: {{ key['user'] }}
+      {%- else %}
+    - user: {{ identifier }}
+      {%- endif %}
+      {%- if 'present' in key and key['present'] and 'source' in key %}
     - source: {{ key['source'] }}
       {%- else %}
         {%- if 'enc' in key %}
@@ -22,21 +25,25 @@ include:
     - options: {{ key['options'] }}
         {%- endif -%}
       {%- endif %}
+{%- endmacro -%}
+
+include:
+  - openssh
+{%- from "openssh/map.jinja" import openssh with context -%}
+{%- set openssh_pillar = pillar.get('openssh', {}) -%}
+{%- set auth = openssh_pillar.get('auth', {}) -%}
+{%- for identifier,keys in auth.items() -%}
+  {%- for key in keys -%}
+    {% if 'present' in key and key['present'] %}
+{{ print_name(identifier, key) }}:
+  ssh_auth.present:
+    {{ print_ssh_auth(identifier, key) }}
     - require:
       - service: {{ openssh.service }}
     {%- else %}
-{{ key['name'] }}:
+{{ print_name(identifier, key) }}:
   ssh_auth.absent:
-    - user: {{ user }}
-      {%- if 'enc' in key %}
-    - enc: {{ key['enc'] }}
-      {%- endif -%}
-      {%- if 'comment' in key %}
-    - comment: {{ key['comment'] }}
-      {%- endif -%}
-      {%- if 'options' in key %}
-    - options: {{ key['options'] }}
-      {%- endif -%}
+    {{ print_ssh_auth(identifier, key) }}
     {%- endif -%}
   {%- endfor -%}
 {%- endfor -%}

--- a/pillar.example
+++ b/pillar.example
@@ -49,12 +49,18 @@ sshd_config:
 
 openssh:
   auth:
-    joe:
-      - name: JOE_VALID_SSH_PUBLIC_KEY
+    joe-valid-ssh-key-desktop:
+      - user: joe
         present: True
         enc: ssh-rsa
-        comment: main key
-      - name: JOE_NON_VALID_SSH_PUBLIC_KEY
+        comment: main key - desktop
+    joe-valid-ssh-key-notebook:
+      - user: joe
+        present: True
+        enc: ssh-rsa
+        comment: main key - notebook
+    joe-non-valid-ssh-key:
+      - user: joe
         present: False
         enc: ssh-rsa
         comment: obsolete key - removed


### PR DESCRIPTION
This change fixes #21 

Now auth.sls is able to use the current format 
```
joe:    # user
  - name: joe
    present: True
    source: salt://ssh_keys/joe.id_rsa.pub
```
or the new format where it's now possible to swap the user and name entry in the pillar
```
joe-desktop:
  - user: joe
    present: True
    source: salt://ssh_keys/joe.desktop.id_rsa.pub
joe-notebook:
  - user: joe
    present: True
    source: salt://ssh_keys/joe.notebook.id_rsa.pub
```