### PR TITLE
Fix mine_function example in pillar.example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -124,6 +124,7 @@ mine_functions:
   public_ssh_host_keys:
     mine_function: cmd.run
     cmd: cat /etc/ssh/ssh_host_*_key.pub
+    python_shell: True
   public_ssh_hostname:
     mine_function: grains.get
     key: id


### PR DESCRIPTION
This fixes #34, salt version 2015.5.x needs an extra argument
for shell routines.