### PR TITLE
Stop messing up the first line in ssh_known_hosts

### DIFF
--- a/openssh/files/ssh_known_hosts
+++ b/openssh/files/ssh_known_hosts
@@ -1,3 +1,7 @@
+{#
+# vi:syntax=jinja
+#}
+
 {%- set target = salt['pillar.get']('openssh:known_hosts:target', '*') -%}
 {%- set expr_form = salt['pillar.get']('openssh:known_hosts:expr_form', 'glob') -%}
 {%- set keys_function = salt['pillar.get']('openssh:known_hosts:mine_keys_function', 'public_ssh_host_keys') -%}


### PR DESCRIPTION
Use jinja comment formatting to prevent the vi syntax line from being included in the ssh_known_hosts file written, which incidentally also corrupts the first line in ssh_known_hosts