### PR TITLE
Added default path for sftp Subsystem in FreeBSD

### DIFF
--- a/openssh/map.jinja
+++ b/openssh/map.jinja
@@ -19,6 +19,7 @@ that differ from whats in defaults.yaml
     'FreeBSD': {
       'service': 'sshd',
       'dig_pkg': 'bind-tools',
+      'Subsystem': 'sftp /usr/libexec/sftp-server',
     },
     'Gentoo': {
       'server': 'net-misc/openssh',


### PR DESCRIPTION
Issue #46 