### PR TITLE
Add support for Host definitions in ssh_config

### DIFF
--- a/openssh/files/ssh_config
+++ b/openssh/files/ssh_config
@@ -68,6 +68,15 @@
 {{ option('   PermitLocalCommand', 'no') }}
 {{ option('   VisualHostKey', 'no') }}
 
+{%- if 'Hosts' in ssh_config %}
+{%- do processed_options.append('Hosts') %}
+{%  for host, conf in ssh_config['Hosts'].items() %}
+Host {{ host }}
+  {%- for key, val in conf.items() %}
+    {{ key }} {{ val }}{%- endfor %}
+{%- endfor %}
+{%- endif %}
+
 {# Handling unknown in salt template options #}
 {%- for keyword in ssh_config.keys() %}
   {#- Matches have to be at the bottom and should be handled differently -#}


### PR DESCRIPTION
This gives us the ability to define system-wide definitions for specific Hosts, and their options.

For example, with this in pillar:

```
# this is the place for host-wide SSH config
ssh_config:
  ...
  Hosts:
    # this simplifies cloning with custom params
    # eg: git clone my-git:foo/bar
    my-git:
      User: git
      HostName: git.example.com
      Port: 2222
```

This would add a section in `/etc/ssh/ssh_config`:

```
Host my-git
    User git
    HostName git.example.com
    Port 2222
```