### PR TITLE
Add sshd_config to map.jinja, and only install dig package if dig command not found.

### DIFF
--- a/openssh/defaults.yaml
+++ b/openssh/defaults.yaml
@@ -8,6 +8,8 @@ openssh:
   ssh_known_hosts: /etc/ssh/ssh_known_hosts
   dig_pkg: dnsutils
   ssh_moduli: /etc/ssh/moduli
+  root_group: root
+sshd_config: {}
 ssh_config:
   Hosts:
     '*':

--- a/openssh/files/sshd_config
+++ b/openssh/files/sshd_config
@@ -1,4 +1,4 @@
-{%- set sshd_config = pillar.get('sshd_config', {}) -%}
+{% from "openssh/map.jinja" import sshd_config with context %}
 {#- present in sshd_config and known in actual file options -#}
 {%- set processed_options = [] -%}
 

--- a/openssh/known_hosts.sls
+++ b/openssh/known_hosts.sls
@@ -1,8 +1,14 @@
 {% from "openssh/map.jinja" import openssh with context %}
 
+check for existing dig:
+  cmd.run:
+    - name: which dig
+
 ensure dig is available:
   pkg.installed:
     - name: {{ openssh.dig_pkg }}
+    - onfail:
+      - cmd: check for existing dig
 
 manage ssh_known_hosts file:
   file.managed:
@@ -10,7 +16,7 @@ manage ssh_known_hosts file:
     - source: salt://openssh/files/ssh_known_hosts
     - template: jinja
     - user: root
-    - group: root
+    - group: {{ openssh.root_group }}
     - mode: 644
     - require:
       - pkg: ensure dig is available

--- a/openssh/map.jinja
+++ b/openssh/map.jinja
@@ -19,7 +19,7 @@ that differ from whats in defaults.yaml
     'FreeBSD': {
       'service': 'sshd',
       'dig_pkg': 'bind-tools',
-      'Subsystem': 'sftp /usr/libexec/sftp-server',
+      'root_group': 'wheel',
     },
     'Gentoo': {
       'server': 'net-misc/openssh',
@@ -38,7 +38,6 @@ that differ from whats in defaults.yaml
       'client': 'openssh',
       'service': 'sshd',
       'dig_pkg': 'bind-utils',
-      'Subsystem': 'sftp /usr/lib/ssh/sftp-server',
     },
   }
   , grain="os_family"
@@ -56,3 +55,27 @@ that differ from whats in defaults.yaml
   )
 %}
 
+{% set os_family_map = salt['grains.filter_by']({
+    'FreeBSD': {
+        'Subsystem': 'sftp /usr/libexec/sftp-server',
+    },
+    'Suse': {
+        'Subsystem': 'sftp /usr/lib/ssh/sftp-server',
+    },
+    'default': {}
+  }
+  , grain="os_family"
+  , merge=salt['pillar.get']('sshd_config:lookup'))
+%}
+
+
+{## Merge the flavor_map to the default settings ##}
+{% do default_settings.sshd_config.update(os_family_map) %}
+
+{## Merge in sshd_config:lookup pillar ##}
+{% set sshd_config = salt['pillar.get'](
+    'sshd_config',
+    default=default_settings.sshd_config,
+    merge=True
+  )
+%}


### PR DESCRIPTION
This PR does the following:

-  Add a separate mapping for the sshd_config dict to map.jinja. Currently, map.jinja adds the sftp subsystem entry to openssh instead of sshd_config (see https://github.com/saltstack-formulas/openssh-formula/pull/57).
- FreeBSD fixes: 
  1. Only install the 'dig' package if no existing dig command is found ([salt.modules.dig](https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.dig.html) uses the dig command line tool). Currently, known_hosts.sls will always install the bind-tools package. However, dig is also provided by the full bind packages, which conflict with bind-tools. Applying this state will therefore remove your dns server :(
  2. Set root group to wheel on FreeBSD hosts. Perhaps it would be easier to fix this one by using the gid (=0) instead of group name (not just in this formula...).