### PR TITLE
Add support for SSH CA signed user keys

### DIFF
--- a/openssh/config.sls
+++ b/openssh/config.sls
@@ -21,6 +21,20 @@ ssh_config:
     - user: root
     - mode: 644
 
+{% if salt['pillar.get']('openssh:absent_trusted_ca_keys', False) %}
+trusted_ca_keys:
+  file.absent:
+    - name: /etc/ssh/trusted_ca_keys
+
+{% elif salt['pillar.get']('openssh:provide_trusted_ca_keys', False) %}
+trusted_ca_keys:
+  file.managed:
+    - name: /etc/ssh/trusted_ca_keys
+    - contents_pillar: 'openssh:trusted_ca_keys:public_key'
+    - user: root
+    - mode: 0600
+{% endif %}
+
 {% for keyType in ['ecdsa', 'dsa', 'rsa', 'ed25519'] %}
 {% if salt['pillar.get']('openssh:generate_' ~ keyType ~ '_keys', False) %}
 ssh_generate_host_{{ keyType }}_key:

--- a/openssh/files/sshd_config
+++ b/openssh/files/sshd_config
@@ -75,6 +75,9 @@
 {{ option_default_uncommented('RSAAuthentication', 'yes') }}
 {{ option_default_uncommented('PubkeyAuthentication', 'yes') }}
 {{ option('AuthorizedKeysFile', '%h/.ssh/authorized_keys') }}
+{%- if salt['pillar.get']('openssh:trusted_ca_keys:public_key') %}
+TrustedUserCAKeys /etc/ssh/trusted_ca_keys
+{%- endif %}
 
 # Don't read the user's ~/.rhosts and ~/.shosts files
 {{ option_default_uncommented('IgnoreRhosts', 'yes') }}

--- a/pillar.example
+++ b/pillar.example
@@ -91,6 +91,12 @@ openssh:
         enc: ssh-rsa
         comment: obsolete key - removed
 
+  absent_trusted_ca_keys: False
+  provide_trusted_ca_keys: False
+  trusted_ca_keys:
+    public_key: |
+      ssh-rsa NOT_DEFINED
+
   generate_dsa_keys: False
   absent_dsa_keys: False
   provide_dsa_keys: False


### PR DESCRIPTION
This change adds support for the TrustedUserCAKeys portion of the SSH CA Signing Authority (OpenSSH 5.4 circa 2010).

OpenSSH supports User/Host Certificate Authority signing which can be used as a replacement to authorized_keys by trusting the signature on the client key.  Further more, configuration options such as Forwarding and the user name the client key can login with can be securely stored within the signed client key preventing the need for complex configuration file options.

See Also:
http://www.lorier.net/docs/ssh-ca
https://www.digitalocean.com/community/tutorials/how-to-create-an-ssh-ca-to-validate-hosts-and-clients-with-ubuntu
