### PR TITLE
Drop overly biased ssh_config defaults

### DIFF
--- a/openssh/defaults.yaml
+++ b/openssh/defaults.yaml
@@ -11,24 +11,7 @@ openssh:
 ssh_config:
   Hosts:
     '*':
-      ForwardAgent: no
-      ForwardX11: no
-      RhostsRSAAuthentication: no
-      RSAAuthentication: yes
-      PasswordAuthentication: yes
-      HostbasedAuthentication: no
-      GSSAPIAuthentication: no
+      SendEnv: LANG LC_*
+      HashKnownHosts: yes
+      GSSAPIAuthentication: yes
       GSSAPIDelegateCredentials: no
-      BatchMode: no
-      CheckHostIP: yes
-      AddressFamily: any
-      ConnectTimeout: 0
-      StrictHostKeyChecking: ask
-      IdentityFile: "~/.ssh/id_rsa"
-      Port: 22
-      Protocol: 2
-      Cipher: 3des
-      Tunnel: no
-      TunnelDevice: "any:any"
-      PermitLocalCommand: no
-      VisualHostKey: no


### PR DESCRIPTION
This set of options reflect the ssh_config options that are set by
default on Debian. The way this was set before has the potential to
break exisisting setups that rely on "normal" defaults, rather than the
rather biased ones that are now being shipped with this formula.

I'd be happy to drop even more, but have the feeling as if the set of 
defaults below reflects, at least, the standard configuration on Debian
systems.

It is, in particular, rather annoying that the IdentityFile is hardcoded to 
`id_rsa` by default as this breaks setups that use newer key types (e.g. 
ed25519) and relied on various key types of them being tried.

The formula should, if it insists on specifying all these options right away
at least stick to the standard OpenSSH default values, rather than the opinionated
ones here.

I hope that we can at least "lighten up" the current burden to specify all sorts
of pillar exceptions for every minion that simply wants to use "the normal defaults".