### PR TITLE
Correct openssh-clients package name for Red Hat

### DIFF
--- a/openssh/map.jinja
+++ b/openssh/map.jinja
@@ -34,7 +34,7 @@ that differ from whats in defaults.yaml
     },
     'RedHat': {
       'server': 'openssh-server',
-      'client': 'openssh',
+      'client': 'openssh-clients',
       'service': 'sshd',
       'dig_pkg': 'bind-utils',
     },


### PR DESCRIPTION
    $ cat /etc/redhat-release 
    CentOS Linux release 7.2.1511 (Core) 
    $ rpm -qf $(which ssh)
    openssh-clients-6.6.1p1-25.el7_2.x86_64