### PR TITLE
Convert dig exist check to unless req to remove spurious change in report

### DIFF
--- a/openssh/known_hosts.sls
+++ b/openssh/known_hosts.sls
@@ -1,14 +1,9 @@
 {% from "openssh/map.jinja" import openssh with context %}
 
-check for existing dig:
-  cmd.run:
-    - name: which dig
-
 ensure dig is available:
   pkg.installed:
     - name: {{ openssh.dig_pkg }}
-    - onfail:
-      - cmd: check for existing dig
+    - unless: which dig
 
 manage ssh_known_hosts file:
   file.managed:


### PR DESCRIPTION
Currently there is a cmd.run state that is always run and always generates a change in the run report.

We can work around this by extending it and adding an unless requisite, like so:
```
include:
  - openssh.known_hosts # "check for existing dig"

extend:
  check for existing dig:
    cmd.run:
      - unless: which dig
```

Alternatively, since the state is only used in one place, we can convert it to an unless requisite for that state. This commit does that.