### PR TITLE
Update name of package containing dig on ArchLinux

### DIFF
--- a/openssh/map.jinja
+++ b/openssh/map.jinja
@@ -10,7 +10,7 @@ that differ from whats in defaults.yaml
       'server': 'openssh',
       'client': 'openssh',
       'service': 'sshd',
-      'dig_pkg': 'bind-utils',
+      'dig_pkg': 'bind-tools',
     },
     'Debian': {
       'server': 'openssh-server',


### PR DESCRIPTION
This change corrects the package name  of the package containing dig so the state can work on a fresh install of ArchLinux.