### PR TITLE
sshd won't start if AddressFamily option is specified

### DIFF
--- a/openssh/files/sshd_config
+++ b/openssh/files/sshd_config
@@ -47,6 +47,10 @@
 # quick reference.
 # See the sshd_config(5) manpage for details
 
+# Specifies which address family should be used by sshd(8).
+# Valid arguments are any, inet (use IPv4 only), or inet6 (use IPv6 only)
+{{ option('AddressFamily', 'any') }}
+
 # What ports, IPs and protocols we listen for
 {{ option('Port', 22) }}
 # Use these options to restrict which interfaces/protocols sshd will bind to


### PR DESCRIPTION
sshd exits with error "address family must be specified before ListenAddress" if the config option AddressFamily is specified. AddressFamily option needs to be moved to top of sshd_config to fix the issue.