### PR TITLE
openssh.auth will produce invalid SLS definition if sshd_config configs are missing

### DIFF
--- a/openssh/auth.sls
+++ b/openssh/auth.sls
@@ -40,7 +40,7 @@ include:
     {{ print_ssh_auth(identifier, key) }}
     {%- if 'sshd_config' in pillar and 'AuthorizedKeysFile' in pillar['sshd_config'] %}
     - config: '{{ pillar['sshd_config']['AuthorizedKeysFile'] }}'
-    {% endif -%}
+    {% endif %}
     - require:
       - service: {{ openssh.service }}
     {%- else %}


### PR DESCRIPTION
openssh.auth will produce invalid SLS definition if no sshd_config is in pillar or AuthorizedKeysFile option missing in pillar.sshd_config, because of a stripped new-line in jinja endif statement on line 43.
```
[CRITICAL] Rendering SLS 'base:openssh.auth' failed: mapping values are not allowed here; line 8

---
[...]

simon-ed25519-ssh-key:
  ssh_auth.present:
    
    - user: root
    - source: salt://ssh_keys/simon.pub- require:    <======================
      - service: ssh
```