### PR TITLE
Add ability to control SSH server service status (default: on)

### DIFF
--- a/openssh/defaults.yaml
+++ b/openssh/defaults.yaml
@@ -1,4 +1,5 @@
 openssh:
+  sshd_enable: True
   sshd_config: /etc/ssh/sshd_config
   sshd_config_src: salt://openssh/files/sshd_config
   ssh_config: /etc/ssh/ssh_config

--- a/openssh/init.sls
+++ b/openssh/init.sls
@@ -5,10 +5,16 @@ openssh:
   pkg.installed:
     - name: {{ openssh.server }}
   {% endif %}
+  {% if openssh.sshd_enable is sameas true %}
   service.running:
-    - enable: True
+    - enable: {{ openssh.sshd_enable }}
     - name: {{ openssh.service }}
   {% if openssh.server is defined %}
     - require:
       - pkg: {{ openssh.server }}
+  {% endif %}
+  {% else %}
+  service.dead:
+    - enable: False
+    - name: {{ openssh.service }}
   {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -81,6 +81,8 @@ ssh_config:
   VisualHostKey: 'no'
 
 openssh:
+  # Controls if SSHD should be enabled/started
+  sshd_enable: true
   auth:
     joe-valid-ssh-key-desktop:
       - user: joe


### PR DESCRIPTION
Add ability to control SSH server service status (default: on)

Updates `pillar.example`

Fixes #78 