### PR TITLE
Add secure defaults to pillar.example + secure sshd_config in defaults.yml #66

### DIFF
--- a/openssh/config.sls
+++ b/openssh/config.sls
@@ -3,6 +3,7 @@
 include:
   - openssh
 
+{% if salt['pillar.get']('sshd_config', False) %}
 sshd_config:
   file.managed:
     - name: {{ openssh.sshd_config }}
@@ -12,7 +13,9 @@ sshd_config:
     - mode: 644
     - watch_in:
       - service: openssh
+{% endif %}
 
+{% if salt['pillar.get']('ssh_config', False) %}
 ssh_config:
   file.managed:
     - name: {{ openssh.ssh_config }}
@@ -20,6 +23,7 @@ ssh_config:
     - template: jinja
     - user: root
     - mode: 644
+{% endif %}
 
 {% for keyType in ['ecdsa', 'dsa', 'rsa', 'ed25519'] %}
 {% if salt['pillar.get']('openssh:generate_' ~ keyType ~ '_keys', False) %}

--- a/openssh/defaults.yaml
+++ b/openssh/defaults.yaml
@@ -10,6 +10,26 @@ openssh:
   dig_pkg: dnsutils
   ssh_moduli: /etc/ssh/moduli
   root_group: root
+  KexAlgorithms:
+    - 'curve25519-sha256@libssh.org'
+    - 'diffie-hellman-group-exchange-sha256'
+  Ciphers:
+    - 'chacha20-poly1305@openssh.com'
+    - 'aes256-gcm@openssh.com'
+    - 'aes128-gcm@openssh.com'
+    - 'aes256-ctr'
+    - 'aes192-ctr'
+    - 'aes128-ctr'
+  MACs:
+    - 'hmac-sha2-512-etm@openssh.com'
+    - 'hmac-sha2-256-etm@openssh.com'
+    - 'hmac-ripemd160-etm@openssh.com'
+    - 'umac-128-etm@openssh.com'
+    - 'hmac-sha2-512'
+    - 'hmac-sha2-256'
+    - 'hmac-ripemd160'
+    - 'umac-128@openssh.com'
+
 sshd_config: {}
 ssh_config:
   Hosts:

--- a/openssh/defaults.yaml
+++ b/openssh/defaults.yaml
@@ -10,31 +10,6 @@ openssh:
   dig_pkg: dnsutils
   ssh_moduli: /etc/ssh/moduli
   root_group: root
-  KexAlgorithms:
-    - 'curve25519-sha256@libssh.org'
-    - 'diffie-hellman-group-exchange-sha256'
-  Ciphers:
-    - 'chacha20-poly1305@openssh.com'
-    - 'aes256-gcm@openssh.com'
-    - 'aes128-gcm@openssh.com'
-    - 'aes256-ctr'
-    - 'aes192-ctr'
-    - 'aes128-ctr'
-  MACs:
-    - 'hmac-sha2-512-etm@openssh.com'
-    - 'hmac-sha2-256-etm@openssh.com'
-    - 'hmac-ripemd160-etm@openssh.com'
-    - 'umac-128-etm@openssh.com'
-    - 'hmac-sha2-512'
-    - 'hmac-sha2-256'
-    - 'hmac-ripemd160'
-    - 'umac-128@openssh.com'
 
 sshd_config: {}
-ssh_config:
-  Hosts:
-    '*':
-      SendEnv: LANG LC_*
-      HashKnownHosts: yes
-      GSSAPIAuthentication: yes
-      GSSAPIDelegateCredentials: no
+ssh_config: {}

--- a/pillar.example
+++ b/pillar.example
@@ -84,6 +84,11 @@ sshd_config:
     - 'hmac-ripemd160'
     - 'umac-128@openssh.com'
 
+# Warning! You should generally NOT NEED to set ssh_config. Setting ssh_config
+# pillar will overwrite the defaults of your distribution's SSH client. This
+# will also force the default configuration for all the SSH clients on the
+# machine. This can break SSH connections with servers using older versions of
+# openssh. Please make sure you understand the implication of different settings
 ssh_config:
   StrictHostKeyChecking: no
   ForwardAgent: no
@@ -107,9 +112,12 @@ ssh_config:
   PermitLocalCommand: 'no'
   VisualHostKey: 'no'
   # Check `man ssh_config` for supported KexAlgorithms, Ciphers and MACs first.
-  # You can specify KexAlgorithms, Ciphers and MACs as both key or a list.
+  # WARNING! Please make sure you understand the implications of the below
+  # settings. The examples provided below might break your connection to older /
+  # legacy openssh servers.
   # The configuration given in the example below is based on:
   # https://stribika.github.io/2015/01/04/secure-secure-shell.html
+  # You can specify KexAlgorithms, Ciphers and MACs as both key or a list.
   #KexAlgorithms: 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1'
   #Ciphers: 'chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
   #MACs: 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128@openssh.com'

--- a/pillar.example
+++ b/pillar.example
@@ -61,14 +61,12 @@ sshd_config:
   # You can specify KexAlgorithms, Ciphers and MACs as both key or a list.
   # The configuration given in the example below is based on:
   # https://stribika.github.io/2015/01/04/secure-secure-shell.html
-  #KexAlgorithms: 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1'
+  #KexAlgorithms: 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256'
   #Ciphers: 'chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
-  #MACs: 'hmac-sha1'
+  #MACs: 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128@openssh.com'
   KexAlgorithms:
     - 'curve25519-sha256@libssh.org'
     - 'diffie-hellman-group-exchange-sha256'
-    - 'diffie-hellman-group-exchange-sha1'
-    - 'diffie-hellman-group14-sha1'
   Ciphers:
     - 'chacha20-poly1305@openssh.com'
     - 'aes256-gcm@openssh.com'
@@ -77,7 +75,14 @@ sshd_config:
     - 'aes192-ctr'
     - 'aes128-ctr'
   MACs:
-    - 'hmac-sha1'
+    - 'hmac-sha2-512-etm@openssh.com'
+    - 'hmac-sha2-256-etm@openssh.com'
+    - 'hmac-ripemd160-etm@openssh.com'
+    - 'umac-128-etm@openssh.com'
+    - 'hmac-sha2-512'
+    - 'hmac-sha2-256'
+    - 'hmac-ripemd160'
+    - 'umac-128@openssh.com'
 
 ssh_config:
   StrictHostKeyChecking: no
@@ -101,6 +106,35 @@ ssh_config:
   TunnelDevice: 'any:any'
   PermitLocalCommand: 'no'
   VisualHostKey: 'no'
+  # Check `man ssh_config` for supported KexAlgorithms, Ciphers and MACs first.
+  # You can specify KexAlgorithms, Ciphers and MACs as both key or a list.
+  # The configuration given in the example below is based on:
+  # https://stribika.github.io/2015/01/04/secure-secure-shell.html
+  #KexAlgorithms: 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1'
+  #Ciphers: 'chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
+  #MACs: 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128@openssh.com'
+  KexAlgorithms:
+    - 'curve25519-sha256@libssh.org'
+    - 'diffie-hellman-group-exchange-sha256'
+    - 'diffie-hellman-group-exchange-sha1'
+    - 'diffie-hellman-group14-sha1'
+  Ciphers:
+    - 'chacha20-poly1305@openssh.com'
+    - 'aes256-gcm@openssh.com'
+    - 'aes128-gcm@openssh.com'
+    - 'aes256-ctr'
+    - 'aes192-ctr'
+    - 'aes128-ctr'
+  MACs:
+    - 'hmac-sha2-512-etm@openssh.com'
+    - 'hmac-sha2-256-etm@openssh.com'
+    - 'hmac-ripemd160-etm@openssh.com'
+    - 'umac-128-etm@openssh.com'
+    - 'hmac-sha2-512'
+    - 'hmac-sha2-256'
+    - 'hmac-ripemd160'
+    - 'umac-128@openssh.com'
+
 
 openssh:
   # Controls if SSHD should be enabled/started

--- a/pillar.example
+++ b/pillar.example
@@ -13,7 +13,7 @@ sshd_config:
     - /etc/ssh/ssh_host_ed25519_key
   UsePrivilegeSeparation: 'yes'
   KeyRegenerationInterval: 3600
-  ServerKeyBits: 768
+  ServerKeyBits: 1024
   SyslogFacility: AUTH
   LogLevel: INFO
   ClientAliveInterval: 0
@@ -35,9 +35,9 @@ sshd_config:
   ChallengeResponseAuthentication: 'no'
   AuthenticationMethods: 'publickey,keyboard-interactive'
   AuthorizedKeysFile: '%h/.ssh/authorized_keys'
-  X11Forwarding: 'yes'
+  X11Forwarding: 'no'
   X11DisplayOffset: 10
-  PrintMotd: 'no'
+  PrintMotd: 'yes'
   PrintLastLog: 'yes'
   TCPKeepAlive: 'yes'
   AcceptEnv: "LANG LC_*"
@@ -58,14 +58,26 @@ sshd_config:
         AllowTcpForwarding: no
         ForceCommand: internal-sftp
   # Check `man sshd_config` for supported KexAlgorithms, Ciphers and MACs first.
-  # For these three keywords, the options may be specified as a list...
+  # You can specify KexAlgorithms, Ciphers and MACs as both key or a list.
+  # The configuration given in the example below is based on:
+  # https://stribika.github.io/2015/01/04/secure-secure-shell.html
+  #KexAlgorithms: 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1'
+  #Ciphers: 'chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
+  #MACs: 'hmac-sha1'
   KexAlgorithms:
-    - diffie-hellman-group14-sha1
-    - diffie-hellman-group1-sha1
-  # ... or a single string.
-  Ciphers: 'aes128-ctr,aes256-ctr'
-  MACs: 'hmac-sha1'
-  # Similar situation for ssh_config
+    - 'curve25519-sha256@libssh.org'
+    - 'diffie-hellman-group-exchange-sha256'
+    - 'diffie-hellman-group-exchange-sha1'
+    - 'diffie-hellman-group14-sha1'
+  Ciphers:
+    - 'chacha20-poly1305@openssh.com'
+    - 'aes256-gcm@openssh.com'
+    - 'aes128-gcm@openssh.com'
+    - 'aes256-ctr'
+    - 'aes192-ctr'
+    - 'aes128-ctr'
+  MACs:
+    - 'hmac-sha1'
 
 ssh_config:
   StrictHostKeyChecking: no


### PR DESCRIPTION
Add secure defaults in `pillar.example`:

- Set `SeverKeyBits` to `1024` (from `768`) ( fixes #47 )
- Set `X11Forwarding` to `no` (from `yes`)
- Set `PrintMotd` to `yes` (from `no`)
- Update `KexAlgorithms`, `Ciphers` and `MACs` examples to include secure configuration based on https://stribika.github.io/2015/01/04/secure-secure-shell.html

Some of these changes can be altered, so let me know what you think. I beliee this would result in providing more secure default `pillar.example` file.