### PR TITLE
PrintLastLog missing in FreeBSD 10.3

### DIFF
--- a/openssh/files/sshd_config
+++ b/openssh/files/sshd_config
@@ -145,7 +145,10 @@
 {{ option('AllowTcpForwarding', 'yes') }}
 {{ option_default_uncommented('X11DisplayOffset', '10') }}
 {{ option_default_uncommented('PrintMotd', 'no') }}
+{# Bug in FreeBSD 10.3 (?) See https://lists.freebsd.org/pipermail/freebsd-stable/2016-April/084501.html #}
+{% if not (salt['grains.get']('os') == 'FreeBSD' and salt['grains.get']('osrelease') == '10.3') -%}
 {{ option_default_uncommented('PrintLastLog', 'yes') }}
+{% endif -%}
 {{ option_default_uncommented('TCPKeepAlive', 'yes') }}
 {{ option('UseLogin', 'no') }}
 


### PR DESCRIPTION
The config option `PrintLastLog` is missing in FreeBSD 10.3. This patch disables the default setting `PrintLastLog yes`.