### PR TITLE
Add variables for file owner and mode

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,7 +21,9 @@ provisioner:
         '*':
           - openssl
     openssl.sls:
-      sshd_enable: true
+      openssh:
+        sshd_config_mode: '600'
+        ssh_config_mode: '600'
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,7 +23,6 @@ provisioner:
     openssl.sls:
       openssh:
         sshd_config_mode: '600'
-        ssh_config_mode: '600'
 
 suites:
   - name: default

--- a/openssh/config.sls
+++ b/openssh/config.sls
@@ -8,8 +8,9 @@ sshd_config:
     - name: {{ openssh.sshd_config }}
     - source: {{ openssh.sshd_config_src }}
     - template: jinja
-    - user: root
-    - mode: 644
+    - user: {{ openssh.sshd_config_user }}
+    - group: {{ openssh.sshd_config_group }}
+    - mode: {{ openssh.sshd_config_mode }}
     - watch_in:
       - service: openssh
 
@@ -18,8 +19,9 @@ ssh_config:
     - name: {{ openssh.ssh_config }}
     - source: {{ openssh.ssh_config_src }}
     - template: jinja
-    - user: root
-    - mode: 644
+    - user: {{ openssh.ssh_config_user }}
+    - group: {{ openssh.ssh_config_group }}
+    - mode: {{ openssh.ssh_config_mode }}
 
 {% for keyType in ['ecdsa', 'dsa', 'rsa', 'ed25519'] %}
 {% if salt['pillar.get']('openssh:generate_' ~ keyType ~ '_keys', False) %}

--- a/openssh/defaults.yaml
+++ b/openssh/defaults.yaml
@@ -2,8 +2,14 @@ openssh:
   sshd_enable: True
   sshd_config: /etc/ssh/sshd_config
   sshd_config_src: salt://openssh/files/sshd_config
+  sshd_config_user: root
+  sshd_config_group: root
+  sshd_config_mode: '644'
   ssh_config: /etc/ssh/ssh_config
   ssh_config_src: salt://openssh/files/ssh_config
+  ssh_config_user: root
+  ssh_config_group: root
+  ssh_config_mode: '644'
   banner: /etc/ssh/banner
   banner_src: salt://openssh/files/banner
   ssh_known_hosts: /etc/ssh/ssh_known_hosts

--- a/test/integration/default/serverspec/openssl_server_spec.rb
+++ b/test/integration/default/serverspec/openssl_server_spec.rb
@@ -21,7 +21,7 @@ describe 'openssl/config.sls' do
   end
 
   describe file('/etc/ssh/ssh_config') do
-    it { should be_mode 600 }
+    it { should be_mode 644 }
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
   end

--- a/test/integration/default/serverspec/openssl_server_spec.rb
+++ b/test/integration/default/serverspec/openssl_server_spec.rb
@@ -14,4 +14,16 @@ describe 'openssl/config.sls' do
     it { should be_running }
   end
 
+  describe file('/etc/ssh/sshd_config') do
+    it { should be_mode 600 }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+  end
+
+  describe file('/etc/ssh/ssh_config') do
+    it { should be_mode 600 }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+  end
+
 end


### PR DESCRIPTION
Permit customization of file owner and mode for `ssh_config` and `sshd_config`. I added this because the current default is 644, but CIS benchmarks recommend 600.