### PR TITLE
openssh.auth_map

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,13 @@ Installs the ``openssh`` server package and service.
 
 Manages SSH certificates for users.
 
+``openssh.auth_map``
+-----------
+
+Same functionality as openssh.auth but with a simplified Pillar syntax.
+Plays nicely with `Pillarstack
+<https://docs.saltstack.com/en/latest/ref/pillar/all/salt.pillar.stack.html>`_.
+
 ``openssh.banner``
 ------------------
 

--- a/openssh/auth_map.sls
+++ b/openssh/auth_map.sls
@@ -1,0 +1,33 @@
+include:
+  - openssh
+
+{%  from "openssh/map.jinja" import openssh with context -%}
+{%- set openssh_pillar = salt["pillar.get"]("openssh", {}) -%}
+{%- set authorized_keys_file = salt["pillar.get"]("sshd_config:AuthorizedKeysFile", None) %}
+
+{%- for store, config in salt["pillar.get"]("openssh:auth_map", {}).iteritems() %}
+{%- set store_base = config["source"] %}
+# SSH store openssh:auth_map:{{ store }}
+{%-   for user, keys in config.get("users", {}).iteritems() %}
+{%-     for key, key_cfg in keys.iteritems() %}
+"ssh_auth--{{ store }}--{{ user }}--{{ key }}":
+{%-       set present = key_cfg.get("present", True) %}
+{%-       set options = key_cfg.get("options", []) %}
+{%-       if present %}
+  ssh_auth.present:
+    - require:
+      - service: {{ openssh.service }}
+{%-       else %}
+  ssh_auth.absent:
+{%-       endif %}
+    - user: {{ user }}
+    - source: {{ store_base }}/{{ key }}.pub
+{%-       if authorized_keys_file %}
+    - config: "{{ authorized_keys_file }}"
+{%-       endif %}
+{%-       if options %}
+    - options: "{{ options }}"
+{%-       endif %}
+{%-     endfor %}
+{%-   endfor %}
+{%- endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -166,6 +166,19 @@ openssh:
         enc: ssh-rsa
         comment: obsolete key - removed
         source: salt://ssh_keys/joe.no-valid.pub
+  # Maps users to source files
+  # Designed to play nice with ext_pillar
+  # salt.states.ssh_auth: If source is set, comment and enc will be ignored
+  auth_map:
+    personal_keys:  # store name
+      source: salt://ssh_keys
+      users:
+        joe:
+          joe.desktop: {}
+          joe.netbook:
+            options: []  # see salt.states.ssh_auth.present
+          joe.no-valid:
+            present: False
 
   generate_dsa_keys: False
   absent_dsa_keys: False


### PR DESCRIPTION
Hi!

Just wrote `openssh.auth_map`.
It provides essentially the same functionality as `openssh.auth` but with a simplified Pillar syntax.
Plays nicely with [Pillarstack](https://docs.saltstack.com/en/latest/ref/pillar/all/salt.pillar.stack.html)

Has anybody any suggestions or remarks? (If not, I'll merge in two to three days.)

Alex