### PR TITLE
Test config before applying it

### DIFF
--- a/openssh/config.sls
+++ b/openssh/config.sls
@@ -12,6 +12,7 @@ sshd_config:
     - user: {{ openssh.sshd_config_user }}
     - group: {{ openssh.sshd_config_group }}
     - mode: {{ openssh.sshd_config_mode }}
+    - check_cmd: {{ openssh.sshd_binary }} -t -f
     - watch_in:
       - service: {{ openssh.service }}
 {% endif %}

--- a/openssh/defaults.yaml
+++ b/openssh/defaults.yaml
@@ -1,5 +1,6 @@
 openssh:
   sshd_enable: True
+  sshd_binary: /usr/sbin/sshd
   sshd_config: /etc/ssh/sshd_config
   sshd_config_src: salt://openssh/files/sshd_config
   sshd_config_user: root


### PR DESCRIPTION
I managed to lock myself out of two servers for the third time now. :-) (Aparently `HostKeyAlgorithms` is unknown to `OpenSSH_6.7p1 Debian-5+deb8u3`...)
In anticipation of funny configuration bugs and/or my stupdity this PR adds a test prior to the change of `sshd_config`.

1. Fill `sshd_config.saltstack-test` with the exact same content which `sshd_config` should later contain.
2. Test it! `sshd -t -f /path/to/sshd_config.saltstack-test`
3. Iff (if and only if) that command succeeded change the actual config.

