### PR TITLE
PrintLastLog missing in FreeBSD 11.0

### DIFF
--- a/openssh/files/sshd_config
+++ b/openssh/files/sshd_config
@@ -146,7 +146,7 @@
 {{ option_default_uncommented('X11DisplayOffset', '10') }}
 {{ option_default_uncommented('PrintMotd', 'no') }}
 {# Bug in FreeBSD 10.3 (?) See https://lists.freebsd.org/pipermail/freebsd-stable/2016-April/084501.html #}
-{% if not (salt['grains.get']('os') == 'FreeBSD' and salt['grains.get']('osrelease') == '10.3') -%}
+{% if not (salt['grains.get']('os') == 'FreeBSD' and salt['grains.get']('osrelease')|float >= 10.3) -%}
 {{ option_default_uncommented('PrintLastLog', 'yes') }}
 {% endif -%}
 {{ option_default_uncommented('TCPKeepAlive', 'yes') }}


### PR DESCRIPTION
The fix introduced in 678cc9066cb358b8a436341b4e31b796b4d82a4c
suppresses the PrintLastLog directive for FreeBSD 10.3.
SSH on FreeBSD 11.0 also does not support PrintLastLog, so this
change suppresses it for any version >= 10.3.