### PR TITLE
Support Match prioritization

### DIFF
--- a/openssh/files/sshd_config
+++ b/openssh/files/sshd_config
@@ -215,8 +215,8 @@
 
 {# Handle matches last as they need to go at the bottom #}
 {%- if 'matches' in sshd_config %}
-  {%- for match in sshd_config['matches'].values() %}
-Match {{ match['type'].keys()[0] }} {{ match['type'].values()[0] }}
+  {%- for name, match in sshd_config['matches']|dictsort(true) %}
+Match {{ match['type'].keys()[0] }} {{ match['type'].values()[0] }} # {{ name }}
     {%- for keyword in match['options'].keys() %}
     {{ render_option(keyword, '', config_dict=match['options']) }}
     {%- endfor %}


### PR DESCRIPTION
OpenSSH's Match declarations are applied first-match-wins. However, we
can't safely define two Matches that might overlap unless we first sort
the keys, as Python (and Jinja) dicts don't guarantee the order of
dict keys,

We also won't scramble the match sequence every time the user adds,
removes or renames a match, and so we give the user clearer, more
concise diffs as when they apply changes.

Finally, we leave a comment on the Match line identifying where the
Match rule came from, to assist in troubleshooting.