### PR TITLE
Fix errors with AuthorizedKeys directives

### DIFF
--- a/openssh/files/sshd_config
+++ b/openssh/files/sshd_config
@@ -128,8 +128,14 @@
 {{ option_default_uncommented('RSAAuthentication', 'yes') }}
 {{ option_default_uncommented('PubkeyAuthentication', 'yes') }}
 {{ option('AuthorizedKeysFile', '%h/.ssh/authorized_keys') }}
-{{ option('AuthorizedKeysCommand', 'none') }}
-{{ option('AuthorizedKeysCommandUser', 'nobody') }}
+{%- if server.authorized_keys_command is defined %}
+AuthorizedKeysCommand {{ server.authorized_keys_command.command }}
+{% if grains['os_family'] == 'RedHat' %}
+{% if grains['osmajorrelease'] != '6' %}
+AuthorizedKeysCommandUser {{ server.authorized_keys_command.get('user', 'nobody') }}
+{%- endif %}
+{%- endif %}
+{%- endif %}
 
 # Don't read the user's ~/.rhosts and ~/.shosts files
 {{ option_default_uncommented('IgnoreRhosts', 'yes') }}

--- a/pillar.example
+++ b/pillar.example
@@ -26,8 +26,9 @@ sshd_config:
   MaxSessions: 10
   RSAAuthentication: 'yes'
   PubkeyAuthentication: 'yes'
-  AuthorizedKeysCommand: '/usr/bin/sss_ssh_authorizedkeys'
-  AuthorizedKeysCommandUser: 'nobody'
+  AuthorizedKeysCommand: 
+    - Command: '/usr/bin/sss_ssh_authorizedkeys'
+    - User: 'nobody'
   IgnoreRhosts: 'yes'
   RhostsRSAAuthentication: 'no'
   HostbasedAuthentication: 'no'


### PR DESCRIPTION
Some distros get mad if certian options are present,This should help resolve those issues.