### PR TITLE
UsePrivilegeSeparation 'sandbox'

### DIFF
--- a/openssh/files/sshd_config
+++ b/openssh/files/sshd_config
@@ -103,7 +103,7 @@
 {{ option_default_uncommented('HostKey', ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_dsa_key', '/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key']) -}}
 
 #Privilege Separation is turned on for security
-{{ option_default_uncommented('UsePrivilegeSeparation', 'yes') }}
+{{ option_default_uncommented('UsePrivilegeSeparation', 'sandbox') }}
 
 # Lifetime and size of ephemeral version 1 server key
 {{ option_default_uncommented('KeyRegenerationInterval', 3600) }}

--- a/pillar.example
+++ b/pillar.example
@@ -11,7 +11,7 @@ sshd_config:
     - /etc/ssh/ssh_host_dsa_key
     - /etc/ssh/ssh_host_ecdsa_key
     - /etc/ssh/ssh_host_ed25519_key
-  UsePrivilegeSeparation: 'yes'
+  UsePrivilegeSeparation: 'sandbox'
   KeyRegenerationInterval: 3600
   ServerKeyBits: 1024
   SyslogFacility: AUTH


### PR DESCRIPTION
This is was introduced in 5.9, and is default in 6.1.
https://www.openssh.com/txt/release-5.9
https://www.openssh.com/txt/release-6.1

It will stick with us for some time although it is going to be deprecated in 7.5.
https://www.openssh.com/txt/release-7.5