### PR TITLE
Hostnames in known hosts

### DIFF
--- a/openssh/files/ssh_known_hosts
+++ b/openssh/files/ssh_known_hosts
@@ -2,10 +2,41 @@
 # vi:syntax=jinja
 #}
 
+{#- Generates one known_hosts entry per given key #}
+{%- macro known_host_entry(host, host_names, keys) %}
+
+{#-   Get IPv4 and IPv6 addresses from the DNS #}
+{%-   set ip4 = salt['dig.A'](host) -%}
+{%-   set ip6 = salt['dig.AAAA'](host) -%}
+
+{#-   The host names to use are to be found within the dict 'host_names'. #}
+{#-   If there are none, the host is used directly. #}
+{%-   set names = [host_names.get(host, host)] -%}
+
+{#-   Append IP addresses and aliases (if they are not already present) #}
+{%-   for ip in (ip4 + ip6)|sort -%}
+{%-     do names.append(ip) -%}
+{%-     for alias in aliases_ips.get(ip, []) -%}
+{%-       if alias not in names -%}
+{%-         do names.append(alias) -%}
+{%-       endif -%}
+{%-     endfor -%}
+{%-   endfor -%}
+
+{#-   Write one line per key; join the names together #}
+{%-   for line in keys.split('\n') -%}
+{%-     if line -%}
+{{        ','.join(names) }} {{ line }}
+{%      endif -%}
+{%-   endfor -%}
+{%- endmacro -%}
+
+{#- Pre-fetch pillar data #}
 {%- set target = salt['pillar.get']('openssh:known_hosts:target', '*') -%}
 {%- set expr_form = salt['pillar.get']('openssh:known_hosts:expr_form', 'glob') -%}
 {%- set keys_function = salt['pillar.get']('openssh:known_hosts:mine_keys_function', 'public_ssh_host_keys') -%}
 {%- set hostname_function = salt['pillar.get']('openssh:known_hosts:mine_hostname_function', 'public_ssh_hostname') -%}
+
 {#- Lookup IP of all aliases so that when we have a matching IP, we inject the alias name
     in the SSH known_hosts entry -#}
 {%- set aliases = salt['pillar.get']('openssh:known_hosts:aliases', []) -%}
@@ -15,24 +46,10 @@
     {%- do aliases_ips.setdefault(ip, []).append(alias) -%}
   {%- endfor -%}
 {%- endfor -%}
+
 {#- Loop over targetted minions -#}
 {%- set host_keys = salt['mine.get'](target, keys_function, expr_form=expr_form) -%}
 {%- set host_names = salt['mine.get'](target, hostname_function, expr_form=expr_form) -%}
 {%- for host, keys in host_keys|dictsort -%}
-  {%- set ip4 = salt['dig.A'](host) -%}
-  {%- set ip6 = salt['dig.AAAA'](host) -%}
-  {%- set names = [host_names.get(host, host)] -%}
-  {%- for ip in (ip4 + ip6)|sort -%}
-    {%- do names.append(ip) -%}
-    {%- for alias in aliases_ips.get(ip, []) -%}
-      {%- if alias not in names -%}
-        {%- do names.append(alias) -%}
-      {%- endif -%}
-    {%- endfor -%}
-  {%- endfor -%}
-  {%- for line in keys.split('\n') -%}
-  {%- if line -%}
-{{ ','.join(names) }} {{ line }}
-{% endif -%}
-  {%- endfor -%}
+{{ known_host_entry(host, host_names, keys) }}
 {%- endfor -%}

--- a/openssh/files/ssh_known_hosts
+++ b/openssh/files/ssh_known_hosts
@@ -13,6 +13,18 @@
 {#-   If there are none, the host is used directly. #}
 {%-   set names = [host_names.get(host, host)] -%}
 
+{#-   Extract the hostname from the FQDN and add it to the names. #}
+{%-   if use_hostnames is iterable -%}
+{%-     for name in names | sort -%}
+{%-       if salt["match.{}".format(hostnames_expr_form)](hostnames_target, minion_id=name) -%}
+{%-         set hostname = name.split('.')|first -%}
+{%-         if hostname not in names -%}
+{%-           do names.append(hostname) -%}
+{%-         endif -%}
+{%-       endif -%}
+{%-     endfor -%}
+{%-   endif -%}
+
 {#-   Append IP addresses and aliases (if they are not already present) #}
 {%-   for ip in (ip4 + ip6)|sort -%}
 {%-     do names.append(ip) -%}
@@ -36,6 +48,10 @@
 {%- set expr_form = salt['pillar.get']('openssh:known_hosts:expr_form', 'glob') -%}
 {%- set keys_function = salt['pillar.get']('openssh:known_hosts:mine_keys_function', 'public_ssh_host_keys') -%}
 {%- set hostname_function = salt['pillar.get']('openssh:known_hosts:mine_hostname_function', 'public_ssh_hostname') -%}
+{%- set use_hostnames = salt['pillar.get']('openssh:known_hosts:hostnames', False) -%}
+{%- set hostnames_target_default = '*' if grains['domain'] == '' else "*.{}".format(grains['domain']) -%}
+{%- set hostnames_target = salt['pillar.get']('openssh:known_hosts:hostnames:target', hostnames_target_default) -%}
+{%- set hostnames_expr_form = salt['pillar.get']('openssh:known_hosts:hostnames:expr_form', 'glob') -%}
 
 {#- Lookup IP of all aliases so that when we have a matching IP, we inject the alias name
     in the SSH known_hosts entry -#}

--- a/pillar.example
+++ b/pillar.example
@@ -277,6 +277,17 @@ openssh:
     aliases:
       - cname-to-minion.example.org
       - alias.example.org
+    # Includes short hostnames derived from the FQDN
+    # (host.example.test -> host)
+    # (Deactivated by default, because there can be collisions!)
+    hostnames: False
+    #hostnames:
+    # Restrict wich hosts you want to use via their hostname
+    # (i.e. ssh user@host instead of ssh user@host.example.com)
+    #  target: '*'  # Defaults to "*.{}".format(grains['domain']) with a fallback to '*'
+    #  expr_form: 'glob'
+    # To activate the defaults you can just set an empty dict.
+    #hostnames: {}
 
   # specify DH parameters (see /etc/ssh/moduli)
   moduli: |


### PR DESCRIPTION
- Added a macro `known_hosts_entry` and comments to increase clarity.
- Opt-in (via pillar): add hostnames to `/etc/ssh/ssh_known_hosts`

Grants a wish: #110 ;-)

@doubletwist13 does that solve your problem?

Tested on Ubuntu 16.04 and FreeBSD 10.3.