### PR TITLE
Add ConfigBanner to processed_options when handled.

### DIFF
--- a/openssh/files/sshd_config
+++ b/openssh/files/sshd_config
@@ -74,9 +74,10 @@
 {%- endmacro -%}
 
 {%- if sshd_config.get('ConfigBanner', False) -%}
-{{ sshd_config['ConfigBanner'] }}
+  {%- do processed_options.append('ConfigBanner') -%}
+  {{ sshd_config['ConfigBanner'] }}
 {%- else -%}
-# This file is managed by salt. Manual changes risk being overwritten.
+  # This file is managed by salt. Manual changes risk being overwritten.
 {%- endif %}
 {%- set global_src_url = salt ['pillar.get']('__formulas:print_template_url', None) %}
 {%- set local_src_url = salt ['pillar.get']('openssh-formula:print_template_url', None) %}


### PR DESCRIPTION
This prevents a verbatim version being added to end of file that will
cause the parsing to fail.