### PR TITLE
Remove deprecated options from openssh/files/sshd_config and pillar.e…

### DIFF
--- a/openssh/files/sshd_config
+++ b/openssh/files/sshd_config
@@ -101,14 +101,10 @@
 {{ option('ListenAddress', ['::', '0.0.0.0']) }}
 {{ option_default_uncommented('Protocol', 2) }}
 # HostKeys for protocol version 2
-{{ option_default_uncommented('HostKey', ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_dsa_key', '/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key']) -}}
+{{ option_default_uncommented('HostKey', ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key']) -}}
 
 #Privilege Separation is turned on for security
 {{ option_default_uncommented('UsePrivilegeSeparation', 'sandbox') }}
-
-# Lifetime and size of ephemeral version 1 server key
-{{ option_default_uncommented('KeyRegenerationInterval', 3600) }}
-{{ option_default_uncommented('ServerKeyBits', 1024) }}
 
 # Logging
 {{ option_default_uncommented('SyslogFacility', 'AUTH') }}
@@ -126,7 +122,6 @@
 {{ option_default_uncommented('MaxSessions', '10') }}
 
 {{ option('DSAAuthentication', 'yes') }}
-{{ option_default_uncommented('RSAAuthentication', 'yes') }}
 {{ option_default_uncommented('PubkeyAuthentication', 'yes') }}
 {{ option('AuthorizedKeysFile', '%h/.ssh/authorized_keys') }}
 {{ option('AuthorizedKeysCommand', 'none') }}
@@ -134,8 +129,6 @@
 
 # Don't read the user's ~/.rhosts and ~/.shosts files
 {{ option_default_uncommented('IgnoreRhosts', 'yes') }}
-# For this to work you will also need host keys in /etc/ssh_known_hosts
-{{ option_default_uncommented('RhostsRSAAuthentication', 'no') }}
 # similar for protocol version 2
 {{ option_default_uncommented('HostbasedAuthentication', 'no') }}
 # Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication

--- a/pillar.example
+++ b/pillar.example
@@ -8,12 +8,9 @@ sshd_config:
   Protocol: 2
   HostKey:
     - /etc/ssh/ssh_host_rsa_key
-    - /etc/ssh/ssh_host_dsa_key
     - /etc/ssh/ssh_host_ecdsa_key
     - /etc/ssh/ssh_host_ed25519_key
   UsePrivilegeSeparation: 'sandbox'
-  KeyRegenerationInterval: 3600
-  ServerKeyBits: 1024
   SyslogFacility: AUTH
   LogLevel: INFO
   ClientAliveInterval: 0
@@ -148,8 +145,6 @@ ssh_config:
   StrictHostKeyChecking: no
   ForwardAgent: no
   ForwardX11: no
-  RhostsRSAAuthentication: no
-  RSAAuthentication: yes
   PasswordAuthentication: yes
   HostbasedAuthentication: no
   GSSAPIAuthentication: no


### PR DESCRIPTION
The aim of this pull request is to avoid those messages in /var/log/messages

2479 Nov 11 23:34:02 sshd[31161]: rexec line 26: Deprecated option KeyRegenerationInterval
2480 Nov 11 23:34:02 sshd[31161]: rexec line 27: Deprecated option ServerKeyBits
2481 Nov 11 23:34:02 sshd[31161]: rexec line 45: Deprecated option RSAAuthentication
2482 Nov 11 23:34:02 sshd[31161]: rexec line 54: Deprecated option RhostsRSAAuthentication

Furtermore dsa host key has been deprecated