### PR TITLE
[openssh/config_ini] initial version of config_ini which uses ini state

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,16 @@ of the default ``sshd_config`` file on Debian Wheezy.
 It is highly recommended ``PermitRootLogin`` is added to pillar
 so root login will be disabled.
 
+``openssh.config_ini``
+----------------------
+
+Version of managing ``sshd_config`` that uses the 
+`ini_managed.option_present <https://docs.saltstack.com/en/latest/ref/states/all/salt.states.ini_manage.html>`_
+state module, so it enables to override only one or 
+multiple values and keeping the defaults shipped by your 
+distribution. 
+
+
 ``openssh.known_hosts``
 -----------------------
 

--- a/openssh/config_ini.sls
+++ b/openssh/config_ini.sls
@@ -1,0 +1,17 @@
+{% from "openssh/map.jinja" import openssh with context %}
+
+include:
+  - openssh
+
+{% if salt['pillar.get']('sshd_config', False) %}
+sshd_config-with-ini:
+  ini.options_present:
+    - name: {{ openssh.sshd_config }}
+    - separator: ' '
+    - watch_in:
+      - service: {{ openssh.service }}
+    - sections:
+        {%- for k,v in salt['pillar.get']('sshd_config',{}).items() %}
+        {{ k }}: '{{ v }}'
+        {%- endfor %}
+{% endif %}


### PR DESCRIPTION
closes #123