### PR TITLE
Add host keys from pillar to `ssh_known_hosts`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,8 +64,9 @@ distribution.
 ``openssh.known_hosts``
 -----------------------
 
-Manages the site-wide ssh_known_hosts file and fills it with the
-public SSH host keys of all minions. You can restrict the set of minions
+Manages the side-wide ssh_known_hosts file and fills it with the
+public SSH host keys of your minions (collected via the Salt mine)
+and of hosts listed in you pillar data. You can restrict the set of minions
 whose keys are listed by using the pillar data ``openssh:known_hosts:target``
 and ``openssh:known_hosts:tgt_type`` (those fields map directly to the
 corresponding attributes of the ``mine.get`` function).
@@ -101,6 +102,16 @@ list in the ``openssh:known_hosts:aliases`` pillar key. Whenever the IPv4 or
 IPv6 behind one of those DNS entries matches an IPv4 or IPv6 behind the
 official hostname of a minion, the alternate DNS name will be associated to the
 minion's public SSH host key.
+
+To add public keys of hosts not among your minions list them under the
+pillar key ``openssh:known_hosts:static``::
+
+    openssh:
+      known_hosts:
+        static:
+          github.com: 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq[...]'
+          gitlab.com: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABA[...]'
+
 
 ``openssh.moduli``
 -----------------------

--- a/openssh/files/ssh_known_hosts
+++ b/openssh/files/ssh_known_hosts
@@ -66,6 +66,8 @@
 {#- Loop over targetted minions -#}
 {%- set host_keys = salt['mine.get'](target, keys_function, tgt_type=tgt_type) -%}
 {%- set host_names = salt['mine.get'](target, hostname_function, tgt_type=tgt_type) -%}
-{%- for host, keys in host_keys|dictsort -%}
+{%- do host_keys.update(salt['pillar.get']('openssh:known_hosts:static',
+    {}).items()) -%}
+{%- for host, keys in host_keys| dictsort -%}
 {{ known_host_entry(host, host_names, keys) }}
 {%- endfor -%}

--- a/pillar.example
+++ b/pillar.example
@@ -307,6 +307,10 @@ openssh:
     #  tgt_type: 'glob'
     # To activate the defaults you can just set an empty dict.
     #hostnames: {}
+    # Here you can list keys for hosts which are not among your minions:
+    static:
+      github.com: 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGm[...]'
+      gitlab.com: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bN[...]'
 
   # specify DH parameters (see /etc/ssh/moduli)
   moduli: |


### PR DESCRIPTION
Hey there,

I've added some bits to get public host keys from `pillar[`openssh:known_hosts:static']`
into the minions `ssh_known_hosts` file. No reason to have everyone check the keys
for things like gitlab themselves, right?

Tested on Ubuntu trusty & xenial, CentOS 6(.9) & 7(.4) and FreeBSD 10.4 & 11.1.

Regards, Florian