### PR TITLE
Debian: Create privilege separation directory

### DIFF
--- a/openssh/config.sls
+++ b/openssh/config.sls
@@ -6,6 +6,16 @@ include:
   - openssh
 
 {% if manage_sshd_config %}
+{% if 'Debian' == salt['grains.get']('os_family') %}
+/run/sshd:
+  file.directory:
+    - user: 0
+    - group: 0
+    - mode: 0755
+    - require_in:
+        - file: sshd_config
+{% endif %}
+
 sshd_config:
   file.managed:
     - name: {{ openssh.sshd_config }}


### PR DESCRIPTION
On Debian-based system, the privilege separation directory is
`/run/sshd`. Since `/run` is a tmpfs filesystem, the init script is
responsible for creating the directory when starting `sshd`. However,
this directory might not exist if the `ssh` service has not been
started yet.

This patch ensures that the directory exists before storing the
configuration file. It is required to prevent the `check_cmd` from
failing; specifically, to prevent `sshd` from complaining that the
directory does not exist.

Relevant:
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=453285
- https://bugs.launchpad.net/ubuntu/+source/openssh/+bug/45234