### PR TITLE
Support package versions

### DIFF
--- a/openssh/client.sls
+++ b/openssh/client.sls
@@ -3,3 +3,6 @@
 openssh_client:
   pkg.installed:
     - name: {{ openssh.client }}
+    {% if openssh.client_version is defined %}
+    - version: {{ openssh.client_version }}
+    {% endif %}

--- a/openssh/init.sls
+++ b/openssh/init.sls
@@ -4,6 +4,9 @@ openssh:
   {% if openssh.server is defined %}
   pkg.installed:
     - name: {{ openssh.server }}
+  {% if openssh.server_version is defined %}
+    - version: {{ openssh.server_version }}
+  {% endif %}
   {% endif %}
   {% if openssh.sshd_enable is sameas true %}
   service.running:

--- a/pillar.example
+++ b/pillar.example
@@ -202,6 +202,10 @@ openssh:
   banner_string: |
     Welcome to {{ grains['id'] }}!
 
+  # Set installed package version
+  server_version: latest
+  client_version: latest
+
   # Controls if SSHD should be enabled/started
   sshd_enable: true
   auth:


### PR DESCRIPTION
The aim of this pull request is to allow the user to specify a version for server and client installs that should be installed. The version for the client is set by `openssh.client_version`  and for server by `openssh.server_version`.

The version field will only be set if configured if it is defined in the pillar. Therefore the PR will not break existing setups.