### PR TITLE
Resolve gem dependencies across "supported" environments

### DIFF
--- a/test/integration/helpers/serverspec/Gemfile
+++ b/test/integration/helpers/serverspec/Gemfile
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# vim: ft=ruby
+
+# Global source defined as https://rubygems.org
+source 'https://rubygems.org'
+
+# Attempt to fingerprint OS from /etc/os-release where available
+if File.file?("/etc/os-release")
+
+  os_family = ''
+  os_version = ''
+  os_version_full = ''
+
+  # Strip necessary granularity from os-release
+  File.open("/etc/os-release").grep(/(^ID=(.*)$|^VERSION="(.*)"$|^VERSION_ID="(.*)")/) do |line|
+
+      # OS family (Debian/CentOS/Ubuntu)
+      if ( line =~ /^ID=\S/ )
+        os_family = line.split('=')[1]
+        puts "IDENTIFIED os_family = " + os_family
+      end
+
+      # Major revision
+      if ( line =~ /^VERSION_ID="(.*)"$/ )
+        os_version = line.split('=')[1].tr('"','')
+        puts "IDENTIFIED os_version = " + os_version
+      end
+
+      # Vanity name
+      if ( line =~ /^VERSION="(.*)"$/ )
+        os_version_full = line.split('=')[1]
+        puts "IDENTIFIED os_version_full = " + os_version_full
+      end
+
+  end
+
+  # Pinning is broken into os_family and then os_version
+  # to try and avoid conflict.
+  case os_family
+
+    when /debian/
+      # os_family: Debian os_version dependent pins
+      case os_version
+        when /7/
+          puts "busser-serverspec is no longer natively supported on: " + os_version_full
+        when /8/
+          gem 'net-ssh', '~> 4.2.0'
+        else
+          puts "Your distribution is either too old, or supported without pins: " + os_version_full
+      end
+
+    when /centos/
+      # os_family: centos os_version dependent pins
+      print "Switching on " + os_version
+      case os_version
+        when /6/
+          puts "busser-serverspec has no native supported on: " + os_version_full
+        when /7/
+          gem 'net-ssh', '~> 4.2.0'
+        else
+          puts "Your distribution is either too old, or supported without pins: " + os_version_full
+      end
+
+    when /ubuntu/
+      # os_family: ubuntu os_version dependent pins
+      case os_version
+        when /14.04/
+          puts "busser-serverspec is no longer natively supported on: " + os_version_full
+        when /16.04/
+          puts "busser-serverspec is currently supported natively on: " + os_version_full
+        else
+          puts "Your distribution is either too old, or supported without pins: " + os_version_full
+      end
+
+    # No helper support provided
+    else
+      puts "No Gemfile helper support exists for os_family: " + os_family
+  end
+else
+  puts "No Gemfile helper support provided for this suite."
+end


### PR DESCRIPTION
This hacky PR attempts to keep serverspec running natively for the distributions where `busser-serverspec` hasn't been lost entirely; ie: (from suite: ubuntu-14

```
-----> Installing Busser (busser)
Fetching: thor-0.19.0.gem (100%)
Fetching: busser-0.7.1.gem (100%)
       Successfully installed thor-0.19.0
       Successfully installed busser-0.7.1
       2 gems installed
-----> Installing Busser plugin: busser-serverspec
       /usr/lib/ruby/1.9.1/rubygems/installer.rb:390:in `ensure_required_ruby_version_met': rake requires Ruby version >= 2.0.0. (Gem::InstallError)
```

Currently the platforms this fixes tests for are:
- debian-85
- centos-72

More specifically the failure this addresses is:

```
-----> Installing Serverspec..
Fetching: diff-lcs-1.3.gem (100%)
Fetching: rspec-mocks-3.8.0.gem (100%)
Fetching: rspec-expectations-3.8.2.gem (100%)
Fetching: rspec-3.8.0.gem (100%)
Fetching: rspec-its-1.2.0.gem (100%)
Fetching: multi_json-1.13.1.gem (100%)
Fetching: sfl-2.3.gem (100%)
Fetching: net-telnet-0.1.1.gem (100%)
Fetching: net-ssh-5.0.0.rc2.gem (100%)
       /usr/lib/ruby/2.1.0/rubygems/installer.rb:543:in `ensure_required_ruby_version_met': net-ssh requires Ruby version >= 2.2.6. (Gem::InstallError)
```