### PR TITLE
ssh_config: properly render host options

### DIFF
--- a/openssh/files/ssh_config
+++ b/openssh/files/ssh_config
@@ -18,6 +18,24 @@
   {%- endif -%}
 {%- endmacro -%}
 
+{%- macro render_host_option(keyword, value) -%}
+{%- if value is sameas true %}
+    {{ keyword }} yes
+  {%- elif value is sameas false %}
+    {{ keyword }} no
+  {%- elif value is string or value is number %}
+    {{ keyword }} {{ value }}
+  {%- else -%}
+    {%- if keyword in string_or_list_options %}
+    {{ keyword }} {{ value|join(',') }}
+    {%- else %}
+    {%- for single_value in value -%}
+    {{ keyword }} {{ single_value }}
+    {%- endfor -%}
+    {%- endif -%}
+{%- endif -%}
+{%- endmacro -%}
+
 {#- generic renderer used for ssh matches, known options, -#}
 {#- and unknown options -#}
 {%- macro render_option(keyword, default, config_dict=ssh_config) -%}
@@ -85,8 +103,8 @@
 {%- do processed_options.append('Hosts') %}
 {%  for host, conf in ssh_config['Hosts'].items() %}
 Host {{ host }}
-  {%- for key, val in conf.items() %}
-    {{ render_raw_option(key, val) }}
+  {%- for key, val in conf.items() -%}
+    {{ render_host_option(key, val) }}
   {%- endfor %}
 {%- endfor %}
 {%- endif %}

--- a/openssh/files/ssh_config
+++ b/openssh/files/ssh_config
@@ -110,7 +110,7 @@ Host {{ host }}
 {%- endif %}
 
 {# Handling unknown in salt template options #}
-{%- for keyword in ssh_config.keys() %}
+{% for keyword in ssh_config.keys() -%}
   {#- Matches have to be at the bottom and should be handled differently -#}
   {%- if not keyword in processed_options and keyword != 'matches' -%}
     {%- if not keyword in string_or_list_options -%}
@@ -121,17 +121,16 @@ Host {{ host }}
 {{ option_string_or_list(keyword, '', True) }}
     {%- endif -%}
   {%- endif -%}
-{%- endfor %}
+{%- endfor -%}
 
 {# Handle matches last as they need to go at the bottom #}
-{%- if 'matches' in ssh_config %}
+{% if 'matches' in ssh_config -%}
   {%- for match in ssh_config['matches'].values() %}
 Match {{ match['type'].keys()[0] }} {{ match['type'].values()[0] }}
     {%- for keyword in match['options'].keys() %}
     {{ render_option(keyword, '', config_dict=match['options']) }}
     {%- endfor %}
   {%- endfor %}
-{%- endif %}
+{%- endif -%}
 
 {#- vim: set ft=jinja : #}
-


### PR DESCRIPTION
Based on the work of @johnnybubonic in #145 . Thanks for this.

* properly render host options in `/etc/ssh/ssh_config`
* optimized whitespace in `/etc/ssh/ssh_config`

I DID NOT TEST THIS MYSELF, because I currently leave `/etc/ssh/ssh_config` as it is.

Would someone please test the changes against a configuration containing `ssh_config:Hosts`? (@johnnybubonic maybe?)

----

@johnnybubonic I did not include your change regarding `ConfigBanner`, because AFAIK this would prevent `ConfigBanner` from being rendered at all.