### PR TITLE
pillar.example: removed deprecated options

### DIFF
--- a/openssh/files/sshd_config
+++ b/openssh/files/sshd_config
@@ -90,10 +90,6 @@
 {#- Privilege Separation is turned on for security -#}
 {{- option('UsePrivilegeSeparation') -}}
 
-{#- Lifetime and size of ephemeral version 1 server key -#}
-{{- option('KeyRegenerationInterval') -}}
-{{- option('ServerKeyBits') -}}
-
 {#- Logging -#}
 {{- option('SyslogFacility') -}}
 {{- option('LogLevel') -}}
@@ -109,8 +105,6 @@
 {{- option('MaxAuthTries') -}}
 {{- option('MaxSessions') -}}
 
-{{- option('DSAAuthentication') -}}
-{{- option('RSAAuthentication') -}}
 {{- option('PubkeyAuthentication') -}}
 {{- option('AuthorizedKeysFile') -}}
 {{- option('AuthorizedKeysCommand') -}}
@@ -118,8 +112,6 @@
 
 {#- Don't read the user's ~/.rhosts and ~/.shosts files -#}
 {{- option('IgnoreRhosts') -}}
-{#- For this to work you will also need host keys in /etc/ssh_known_hosts -#}
-{{- option('RhostsRSAAuthentication') -}}
 {#- similar for protocol version 2 -#}
 {{- option('HostbasedAuthentication') -}}
 {#- Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication -#}

--- a/pillar.example
+++ b/pillar.example
@@ -12,8 +12,6 @@ sshd_config:
     - /etc/ssh/ssh_host_ecdsa_key
     - /etc/ssh/ssh_host_ed25519_key
   UsePrivilegeSeparation: 'sandbox'
-  KeyRegenerationInterval: 3600
-  ServerKeyBits: 1024
   SyslogFacility: AUTH
   LogLevel: INFO
   ClientAliveInterval: 0
@@ -24,12 +22,10 @@ sshd_config:
   StrictModes: 'yes'
   MaxAuthTries: 6
   MaxSessions: 10
-  RSAAuthentication: 'yes'
   PubkeyAuthentication: 'yes'
   AuthorizedKeysCommand: '/usr/bin/sss_ssh_authorizedkeys'
   AuthorizedKeysCommandUser: 'nobody'
   IgnoreRhosts: 'yes'
-  RhostsRSAAuthentication: 'no'
   HostbasedAuthentication: 'no'
   PermitEmptyPasswords: 'no'
   ChallengeResponseAuthentication: 'no'


### PR DESCRIPTION
Based on #119.

Removed these deprecated options from `pillar.example`:

* KeyRegenerationInterval
* ServerKeyBits
* RSAAuthentication
* RhostsRSAAuthentication