### PR TITLE
Allow removing keys based on source file.

### DIFF
--- a/openssh/auth.sls
+++ b/openssh/auth.sls
@@ -12,7 +12,7 @@
       {%- else %}
     - user: {{ identifier }}
       {%- endif %}
-      {%- if 'present' in key and key['present'] and 'source' in key %}
+      {%- if 'source' in key %}
     - source: {{ key['source'] }}
       {%- else %}
         {%- if 'enc' in key %}


### PR DESCRIPTION
This change allows keys to be not only added, but also removed by providing a `source` file. This is supported by `ssh_auth.absent` since salt 2015.8.0. Hope I have not overlooked anything.