### PR TITLE
Remove duplicated 'pillar.get' calls to retrieve the sshd_config and ssh_config pillars

### DIFF
--- a/openssh/auth.sls
+++ b/openssh/auth.sls
@@ -29,17 +29,16 @@
 
 include:
   - openssh
-{%- from "openssh/map.jinja" import openssh with context -%}
-{%- set openssh_pillar = pillar.get('openssh', {}) -%}
-{%- set auth = openssh_pillar.get('auth', {}) -%}
+{%- from "openssh/map.jinja" import openssh, sshd_config with context -%}
+{%- set auth = openssh.get('auth', {}) -%}
 {%- for identifier,keys in auth.items() -%}
   {%- for key in keys -%}
     {% if 'present' in key and key['present'] %}
 {{ print_name(identifier, key) }}:
   ssh_auth.present:
     {{ print_ssh_auth(identifier, key) }}
-    {%- if 'sshd_config' in pillar and 'AuthorizedKeysFile' in pillar['sshd_config'] %}
-    - config: '{{ pillar['sshd_config']['AuthorizedKeysFile'] }}'
+    {%- if sshd_config.get("AuthorizedKeysFile", None) %}
+    - config: '{{ sshd_config['AuthorizedKeysFile'] }}'
     {% endif %}
     - require:
       - service: {{ openssh.service }}
@@ -47,8 +46,8 @@ include:
 {{ print_name(identifier, key) }}:
   ssh_auth.absent:
     {{ print_ssh_auth(identifier, key) }}
-    {%- if 'sshd_config' in pillar and 'AuthorizedKeysFile' in pillar['sshd_config'] %}
-    - config: '{{ pillar['sshd_config']['AuthorizedKeysFile'] }}'
+    {%- if sshd_config.get("AuthorizedKeysFile", None) %}
+    - config: '{{ sshd_config['AuthorizedKeysFile'] }}'
     {% endif -%}
     {%- endif -%}
   {%- endfor -%}

--- a/openssh/auth_map.sls
+++ b/openssh/auth_map.sls
@@ -1,11 +1,10 @@
 include:
   - openssh
 
-{%  from "openssh/map.jinja" import openssh with context -%}
-{%- set openssh_pillar = salt["pillar.get"]("openssh", {}) -%}
-{%- set authorized_keys_file = salt["pillar.get"]("sshd_config:AuthorizedKeysFile", None) %}
+{%  from "openssh/map.jinja" import openssh, sshd_config with context -%}
+{%- set authorized_keys_file = sshd_config.get("AuthorizedKeysFile", None) %}
 
-{%- for store, config in salt["pillar.get"]("openssh:auth_map", {}).items() %}
+{%- for store, config in openssh.get("auth_map", {}).items() %}
 {%- set store_base = config["source"] %}
 # SSH store openssh:auth_map:{{ store }}
 {%-   for user, keys in config.get("users", {}).items() %}

--- a/openssh/config_ini.sls
+++ b/openssh/config_ini.sls
@@ -1,9 +1,9 @@
-{% from "openssh/map.jinja" import openssh with context %}
+{% from "openssh/map.jinja" import openssh, sshd_config with context %}
 
 include:
   - openssh
 
-{% if salt['pillar.get']('sshd_config', False) %}
+{% if sshd_config %}
 sshd_config-with-ini:
   ini.options_present:
     - name: {{ openssh.sshd_config }}
@@ -11,7 +11,7 @@ sshd_config-with-ini:
     - watch_in:
       - service: {{ openssh.service }}
     - sections:
-        {%- for k,v in salt['pillar.get']('sshd_config',{}).items() %}
+        {%- for k,v in sshd_config.items() %}
         {{ k }}: '{{ v }}'
         {%- endfor %}
 {% endif %}

--- a/openssh/files/ssh_config
+++ b/openssh/files/ssh_config
@@ -1,5 +1,5 @@
-{%- import_yaml "openssh/defaults.yaml" as default_settings -%}
-{%- set ssh_config = salt['pillar.get']('ssh_config', default=default_settings.default.ssh_config, merge=True) -%}
+{% from "openssh/map.jinja" import ssh_config with context %}
+
 {#- present in ssh_config and known in actual file options -#}
 {%- set processed_options = [] -%}
 {%- set string_or_list_options = ['KexAlgorithms', 'Ciphers', 'MACs'] -%}


### PR DESCRIPTION
Follow #160 to remove remaining duplicated 'pillar.get' calls to retrieve the sshd_config and ssh_config pillars.

*Purpose:*
* Do code cleanup.
* Not ignore `sshd_config` & `ssh_config` variables in customized *defaults.yaml*.

*Impacted Files:*
- config_ini.sls
- auth_map.sls
- auth.sls
- files/ssh_config
