### PR TITLE
fix(`config_ini`): convert tabs to single space to prevent false +ves

### DIFF
--- a/openssh/config_ini.sls
+++ b/openssh/config_ini.sls
@@ -1,10 +1,23 @@
-{% from "openssh/map.jinja" import openssh, sshd_config with context %}
+{%- from "openssh/map.jinja" import openssh, sshd_config with context %}
 
 include:
   - openssh
 
-{% if sshd_config %}
+{%- if sshd_config %}
 sshd_config-with-ini:
+  {#- Convert any tabs to a single space to prevent false positives #}
+  {#- Ref: https://github.com/saltstack-formulas/openssh-formula/issues/162 #}
+  {%- set regex_search_for_tabs = '^(\w+)\t+(\w)' %}
+  {%- if salt['file.contains_regex'](openssh.sshd_config, regex_search_for_tabs) %}
+  file.replace:
+    - name: {{ openssh.sshd_config }}
+    - pattern: {{ regex_search_for_tabs }}
+    - repl: '\1 \2'
+    - show_changes: True
+    - require_in:
+      - ini_manage: sshd_config-with-ini
+  {%- endif %}
+
   ini.options_present:
     - name: {{ openssh.sshd_config }}
     - separator: ' '
@@ -14,4 +27,4 @@ sshd_config-with-ini:
         {%- for k,v in sshd_config.items() %}
         {{ k }}: '{{ v }}'
         {%- endfor %}
-{% endif %}
+{%- endif %}


### PR DESCRIPTION
* Fix #162
* Check for any number of tabs after the keyword
* If found, replace them by a single space to match the `separator` used
  in the `ini_options.present` state

---

Note, this comment outlines the whole problem: https://github.com/saltstack-formulas/openssh-formula/issues/162#issuecomment-497110278.

Tested `sshd_config` with all combinations successfully:

Situation | Outcome
---|---
Already using single space per line | Only `ini_options.present` state runs
Single tab per line | Replaced by single space
Multiple tabs per line | Replaced by single space
