### PR TITLE
test(inspec): fix `config_spec` tests on *BSD (`wheel` not `root`)

### DIFF
--- a/test/integration/default/controls/config_spec.rb
+++ b/test/integration/default/controls/config_spec.rb
@@ -1,8 +1,11 @@
 # Overide by Platform
-root_group = 'root'
-if platform[:family] == 'freebsd'
-  root_group = 'wheel'
-end
+root_group =
+  case platform[:family]
+  when 'bsd'
+    'wheel'
+  else
+    'root'
+  end
 
 control 'openssh configuration' do
   title 'should match desired lines'


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [x] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [x] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [x] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Before:

```ruby
  ↺  openssh package: should be installed
     ↺  The `package` resource is not supported on your OS yet.
  ×  openssh configuration: should match desired lines (2 failed)
     ✔  File /etc/ssh/sshd_config is expected to be file
     ✔  File /etc/ssh/sshd_config is expected to be owned by "root"
     ×  File /etc/ssh/sshd_config is expected to be grouped into "root"
     expected `File /etc/ssh/sshd_config.grouped_into?("root")` to return true, got false
     ✔  File /etc/ssh/sshd_config mode is expected to cmp == "0644"
     ✔  File /etc/ssh/sshd_config content is expected to include "ChallengeResponseAuthentication no"
     ✔  File /etc/ssh/sshd_config content is expected to include "X11Forwarding yes"
     ✔  File /etc/ssh/sshd_config content is expected to include "PrintMotd no"
     ✔  File /etc/ssh/sshd_config content is expected to include "AcceptEnv LANG LC_*"
     ✔  File /etc/ssh/sshd_config content is expected to include "Subsystem sftp /usr/lib/openssh/sftp-server"
     ✔  File /etc/ssh/sshd_config content is expected to include "UsePAM yes"
     ✔  File /etc/ssh/ssh_config is expected to be file
     ✔  File /etc/ssh/ssh_config is expected to be owned by "root"
     ×  File /etc/ssh/ssh_config is expected to be grouped into "root"
     expected `File /etc/ssh/ssh_config.grouped_into?("root")` to return true, got false
     ✔  File /etc/ssh/ssh_config mode is expected to cmp == "0644"
     ✔  File /etc/ssh/ssh_config content is expected to include "Host *"
     ✔  File /etc/ssh/ssh_config content is expected to include "    GSSAPIAuthentication yes"
     ✔  File /etc/ssh/ssh_config content is expected to include "    HashKnownHosts yes"
     ✔  File /etc/ssh/ssh_config content is expected to include "    SendEnv LANG LC_*"
  ✔  openssh service: should be running and enabled
     ✔  Service sshd is expected to be enabled
     ✔  Service sshd is expected to be running


Profile Summary: 1 successful control, 1 control failure, 1 control skipped
Test Summary: 18 successful, 2 failures, 1 skipped
```

After:

```ruby
  ↺  openssh package: should be installed
     ↺  The `package` resource is not supported on your OS yet.
  ✔  openssh configuration: should match desired lines
     ✔  File /etc/ssh/sshd_config is expected to be file
     ✔  File /etc/ssh/sshd_config is expected to be owned by "root"
     ✔  File /etc/ssh/sshd_config is expected to be grouped into "wheel"
     ✔  File /etc/ssh/sshd_config mode is expected to cmp == "0644"
     ✔  File /etc/ssh/sshd_config content is expected to include "ChallengeResponseAuthentication no"
     ✔  File /etc/ssh/sshd_config content is expected to include "X11Forwarding yes"
     ✔  File /etc/ssh/sshd_config content is expected to include "PrintMotd no"
     ✔  File /etc/ssh/sshd_config content is expected to include "AcceptEnv LANG LC_*"
     ✔  File /etc/ssh/sshd_config content is expected to include "Subsystem sftp /usr/lib/openssh/sftp-server"
     ✔  File /etc/ssh/sshd_config content is expected to include "UsePAM yes"
     ✔  File /etc/ssh/ssh_config is expected to be file
     ✔  File /etc/ssh/ssh_config is expected to be owned by "root"
     ✔  File /etc/ssh/ssh_config is expected to be grouped into "wheel"
     ✔  File /etc/ssh/ssh_config mode is expected to cmp == "0644"
     ✔  File /etc/ssh/ssh_config content is expected to include "Host *"
     ✔  File /etc/ssh/ssh_config content is expected to include "    GSSAPIAuthentication yes"
     ✔  File /etc/ssh/ssh_config content is expected to include "    HashKnownHosts yes"
     ✔  File /etc/ssh/ssh_config content is expected to include "    SendEnv LANG LC_*"
  ✔  openssh service: should be running and enabled
     ✔  Service sshd is expected to be enabled
     ✔  Service sshd is expected to be running


Profile Summary: 2 successful controls, 0 control failures, 1 control skipped
Test Summary: 20 successful, 0 failures, 1 skipped
```

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

Tested with the following `kitchen.vagrant.yml`:

```yaml
# -*- coding: utf-8 -*-
# vim: ft=yaml
---
driver:
  name: vagrant

platforms:
  - name: freebsd-120-2019-2-py2
    driver:
      box: bento/freebsd-12.0
      cache_directory: false
      customize:
        usbxhci: 'off'
      gui: false
      linked_clone: true

provisioner:
  name: salt_solo
  salt_install: bootstrap
  salt_bootstrap_url: https://bootstrap.saltstack.com
  salt_version: latest
```

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [x] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


