### PR TITLE
feat(ssh_known_hosts): allow to omit IP addresses

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -117,7 +117,7 @@ setup those functions through pillar::
       public_ssh_host_keys:
         mine_function: cmd.run
         cmd: cat /etc/ssh/ssh_host_*_key.pub
-        python_shell: True
+        python_shell: true
       public_ssh_hostname:
         mine_function: grains.get
         key: id
@@ -210,7 +210,7 @@ To **include localhost** and local IP addresses (``127.0.0.1`` and ``::1``) use 
 
     openssh:
       known_hosts:
-        include_localhost: True
+        include_localhost: true
 
 To prevent ever-changing IP addresses from being added to a host, use this::
 
@@ -223,7 +223,7 @@ To completely disable adding IP addresses::
 
     openssh:
       known_hosts:
-        omit_ip_address: True
+        omit_ip_address: true
 
 ``openssh.moduli``
 ^^^^^^^^^^^^^^^^^^

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -212,6 +212,19 @@ To **include localhost** and local IP addresses (``127.0.0.1`` and ``::1``) use 
       known_hosts:
         include_localhost: True
 
+To prevent ever-changing IP addresses from being added to a host, use this::
+
+    openssh:
+      known_hosts:
+        omit_ip_address:
+          - my.host.tld
+
+To completely disable adding IP addresses::
+
+    openssh:
+      known_hosts:
+        omit_ip_address: True
+
 ``openssh.moduli``
 ^^^^^^^^^^^^^^^^^^
 

--- a/openssh/files/default/ssh_known_hosts
+++ b/openssh/files/default/ssh_known_hosts
@@ -3,11 +3,16 @@
 #}
 
 {#- Generates one known_hosts entry per given key #}
-{%- macro known_host_entry(host, host_names, keys, include_localhost) %}
+{%- macro known_host_entry(host, host_names, keys, include_localhost, omit_ip_address) %}
 
 {#-   Get IPv4 and IPv6 addresses from the DNS #}
-{%-   set ip4 = salt['dig.A'](host) -%}
-{%-   set ip6 = salt['dig.AAAA'](host) -%}
+{%-   if not (omit_ip_address is sameas true or host in omit_ip_address) %}
+{%-     set ip4 = salt['dig.A'](host) -%}
+{%-     set ip6 = salt['dig.AAAA'](host) -%}
+{%-   else %}
+{%-     set ip4 = [] -%}
+{%-     set ip6 = [] -%}
+{%-   endif %}
 
 {#-   The host names to use are to be found within the dict 'host_names'. #}
 {#-   If there are none, the host is used directly. #}
@@ -59,6 +64,7 @@
 {%- set hostnames_target = salt['pillar.get']('openssh:known_hosts:hostnames:target', hostnames_target_default) -%}
 {%- set hostnames_tgt_type = salt['pillar.get']('openssh:known_hosts:hostnames:tgt_type', 'glob') -%}
 {%- set include_localhost = salt['pillar.get']('openssh:known_hosts:include_localhost', False) -%}
+{%- set omit_ip_address = salt['pillar.get']('openssh:known_hosts:omit_ip_address', []) -%}
 
 {#- Lookup IP of all aliases so that when we have a matching IP, we inject the alias name
     in the SSH known_hosts entry -#}
@@ -98,5 +104,5 @@
 
 {#- Loop over targetted minions -#}
 {%- for host, keys in host_keys| dictsort -%}
-{{ known_host_entry(host, host_names, keys, include_localhost) }}
+{{ known_host_entry(host, host_names, keys, include_localhost, omit_ip_address) }}
 {%- endfor -%}

--- a/pillar.example
+++ b/pillar.example
@@ -335,6 +335,13 @@ openssh:
     static:
       github.com: 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGm[...]'
       gitlab.com: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bN[...]'
+    # Prevent an ever-changing ssh_known_hosts file caused by a domain which
+    # is served from multiple IP addresses.
+    # To disable completely:
+    # omit_ip_address: true
+    # Or to disable by specific hosts:
+    omit_ip_address:
+      - github.com
 
   # yamllint disable rule:line-length
   # specify DH parameters (see /etc/ssh/moduli)

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -168,6 +168,8 @@ openssh:
     static:
       github.com: 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGm[...]'
       gitlab.com: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bN[...]'
+    omit_ip_address:
+      - github.com
 
   # specify DH parameters (see /etc/ssh/moduli)
   # yamllint disable rule:line-length


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [x] `[docs]`     Documentation changes
- [x] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Servers like `github.com` are hosted on multiple IP addresses. When the IP address is retrieved via DNS this leads to a flapping `/etc/ssh/ssh_known_hosts`. To prevent that fluctuation the Pillar `openssh:known_hosts:omit_ip_address` was introduced. It can either specify a list of hosts or `True`.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

I updated `test/salt/pillar/default.sls`.

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

```
host:                                                                                              
----------                                                                                                            
          ID: manage ssh_known_hosts file                                                                             
    Function: file.managed                                                                                            
        Name: /etc/ssh/ssh_known_hosts                                                                                
      Result: None                                                                                                    
     Comment: The file /etc/ssh/ssh_known_hosts is set to be changed                                                  
              Note: No changes made, actual changes may                                                               
              be different due to other states.                                                                       
     Started: 17:07:06.729371                                                                                         
    Duration: 2172.67 ms                                                                                              
     Changes:                                                                                                         
              ----------                                                                                              
              diff:                                                                                                   
                  ---                                                                                                 
                  +++ 
                  @@ -29,6 +29,7 @@
                   […]
                  -github.com,140.82.118.3,140.82.118.4 ssh-rsa AAAAB3NzaC1yc2E[…] git@github.com
                  +github.com ssh-rsa AAAAB3NzaC1yc2E[…] git@github.com
                   […]
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [x] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [x] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [x] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


