### PR TITLE
Fix Bad configuration option: u'Subsystem'^M

### DIFF
--- a/openssh/osfamilymap.yaml
+++ b/openssh/osfamilymap.yaml
@@ -16,7 +16,7 @@ Debian:
     client: openssh-client
     service: ssh
   sshd_config:
-    Subsystem: sftp /usr/lib/openssh/sftp-server
+    Subsystem: "sftp /usr/lib/openssh/sftp-server"
 
 FreeBSD:
   openssh:


### PR DESCRIPTION
Due an error in parsing