### PR TITLE
fix(jinja): omit_ip_address don't work on some platform

### DIFF
--- a/openssh/files/default/ssh_known_hosts
+++ b/openssh/files/default/ssh_known_hosts
@@ -6,7 +6,7 @@
 {%- macro known_host_entry(host, host_names, keys, include_localhost, omit_ip_address) %}
 
 {#-   Get IPv4 and IPv6 addresses from the DNS #}
-{%-   if not (omit_ip_address is sameas true or host in omit_ip_address) %}
+{%-   if not ((omit_ip_address is sameas true) or (host in omit_ip_address)) %}
 {%-     set ip4 = salt['dig.A'](host) -%}
 {%-     set ip6 = salt['dig.AAAA'](host) -%}
 {%-   else %}


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

It apprears that the

  `if not (omit_ip_address is sameas true or host in omit_ip_address)`

always returns `True` on older Jinja platforms:

- default-ubuntu-1604-3000-3-py2
- default-ubuntu-1604-2019-2-py3
- default-amazonlinux-1-2019-2-py2

Each part of the `or` conditional need to be surrounded by parenthesis.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

Before:

```
       [INFO    ] Executing state file.managed for [/etc/ssh/ssh_known_hosts]
       [DEBUG   ] Returning file list from cache: age=7 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
       [DEBUG   ] Returning file list from cache: age=7 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
       [DEBUG   ] In saltenv 'base', looking at rel_path 'openssh/files/default/ssh_known_hosts' to resolve 'salt://openssh/files/default/ssh_known_hosts'
       [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/openssh/files/default/ssh_known_hosts' to resolve 'salt://openssh/files/default/ssh_known_hosts'
       [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://openssh/files/default/ssh_known_hosts'
       [DEBUG   ] No dest file found
       [INFO    ] Fetching file from saltenv 'base', ** done ** 'openssh/files/default/ssh_known_hosts'
       [DEBUG   ] Jinja search path: ['/tmp/kitchen/var/cache/salt/minion/files/base']
       [INFO    ] Executing command ['dig', '+short', 'cname-to-minion.example.org', 'A'] in directory '/home/kitchen'
       [INFO    ] Executing command ['dig', '+short', 'cname-to-minion.example.org', 'AAAA'] in directory '/home/kitchen'
       [INFO    ] Executing command ['dig', '+short', 'alias.example.org', 'A'] in directory '/home/kitchen'
       [INFO    ] Executing command ['dig', '+short', 'alias.example.org', 'AAAA'] in directory '/home/kitchen'
       [DEBUG   ] LazyLoaded glob_match.match
       [DEBUG   ] LazyLoaded glob_match.match
       [DEBUG   ] LazyLoaded glob_match.match
       [DEBUG   ] LazyLoaded glob_match.match
       [INFO    ] Executing command ['dig', '+short', 'github.com', 'A'] in directory '/home/kitchen'
       [DEBUG   ] stdout: 140.82.118.4
       [INFO    ] Executing command ['dig', '+short', 'github.com', 'AAAA'] in directory '/home/kitchen'
       [INFO    ] Executing command ['dig', '+short', 'gitlab.com', 'A'] in directory '/home/kitchen'
       [DEBUG   ] stdout: 172.65.251.78
       [INFO    ] Executing command ['dig', '+short', 'gitlab.com', 'AAAA'] in directory '/home/kitchen'
       [DEBUG   ] stdout: 2606:4700:90:0:f22e:fbec:5bed:a9b9
       [INFO    ] Executing command ['dig', '+short', 'minion.id', 'A'] in directory '/home/kitchen'
       [INFO    ] Executing command ['dig', '+short', 'minion.id', 'AAAA'] in directory '/home/kitchen'
```

After:

```
       [INFO    ] Executing state file.managed for [/etc/ssh/ssh_known_hosts]
       [DEBUG   ] Returning file list from cache: age=8 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
       [DEBUG   ] Returning file list from cache: age=8 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
       [DEBUG   ] In saltenv 'base', looking at rel_path 'openssh/files/default/ssh_known_hosts' to resolve 'salt://openssh/files/default/ssh_known_hosts'
       [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/openssh/files/default/ssh_known_hosts' to resolve 'salt://openssh/files/default/ssh_known_hosts'
       [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://openssh/files/default/ssh_known_hosts'
       [DEBUG   ] No dest file found
       [INFO    ] Fetching file from saltenv 'base', ** done ** 'openssh/files/default/ssh_known_hosts'
       [DEBUG   ] Jinja search path: ['/tmp/kitchen/var/cache/salt/minion/files/base']
       [INFO    ] Executing command ['dig', '+short', 'cname-to-minion.example.org', 'A'] in directory '/home/kitchen'
       [INFO    ] Executing command ['dig', '+short', 'cname-to-minion.example.org', 'AAAA'] in directory '/home/kitchen'
       [INFO    ] Executing command ['dig', '+short', 'alias.example.org', 'A'] in directory '/home/kitchen'
       [INFO    ] Executing command ['dig', '+short', 'alias.example.org', 'AAAA'] in directory '/home/kitchen'
       [DEBUG   ] LazyLoaded glob_match.match
       [DEBUG   ] LazyLoaded glob_match.match
       [DEBUG   ] LazyLoaded glob_match.match
       [DEBUG   ] LazyLoaded glob_match.match
       [INFO    ] Executing command ['dig', '+short', 'gitlab.com', 'A'] in directory '/home/kitchen'
       [DEBUG   ] stdout: 172.65.251.78
       [INFO    ] Executing command ['dig', '+short', 'gitlab.com', 'AAAA'] in directory '/home/kitchen'
       [DEBUG   ] stdout: 2606:4700:90:0:f22e:fbec:5bed:a9b9
       [INFO    ] Executing command ['dig', '+short', 'minion.id', 'A'] in directory '/home/kitchen'
       [INFO    ] Executing command ['dig', '+short', 'minion.id', 'AAAA'] in directory '/home/kitchen'
       [DEBUG   ] LazyLoaded files.is_text
       [DEBUG   ] LazyLoaded stringutils.get_diff
       [INFO    ] File changed:
       --- 
       +++ 
       @@ -1,4 +1,4 @@
       -github.com,140.82.118.4 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGm[...]
       +github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGm[...]
        gitlab.com,172.65.251.78,2606:4700:90:0:f22e:fbec:5bed:a9b9 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bN[...]
        minion.id,alias.of.minion.id ssh-rsa [...]
        minion.id,alias.of.minion.id ssh-ed25519 [...]
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [x] Included in Kitchen (i.e. under `state_top`).
- [x] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


