### PR TITLE
test(inspec): display proper diff when `_mapdata` mismatch

### DIFF
--- a/test/integration/default/controls/_mapdata_spec.rb
+++ b/test/integration/default/controls/_mapdata_spec.rb
@@ -13,6 +13,6 @@ control '`map.jinja` YAML dump' do
 
   describe file('/tmp/salt_mapdata_dump.yaml') do
     it { should exist }
-    its('content') { should include mapdata_dump }
+    its('content') { should eq mapdata_dump }
   end
 end


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [x] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

#187

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

The use of `eq` instead of `include` premits to have a nice diff after the `expected/got` oneliners.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

N/A

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

Here is the output I get when modifying a `_mapdata` reference file:

```
  ×  `map.jinja` YAML dump: should contain the lines (1 failed)
     ✔  File /tmp/salt_mapdata_dump.yaml is expected to exist
     ×  File /tmp/salt_mapdata_dump.yaml content is expected to eq "# yamllint disable rule:indentation rule:line-length\n# Debian-10\n---\nmap_jinja:\n  config_get_roo...td: 'no'\n  Subsystem: sftp /usr/lib/openssh/sftp-server\n  UsePAM: 'yes'\n  X11Forwarding: 'yes'\n"
     
     expected: "# yamllint disable rule:indentation rule:line-length\n# Debian-10\n---\nmap_jinja:\n  config_get_roo...td: 'no'\n  Subsystem: sftp /usr/lib/openssh/sftp-server\n  UsePAM: 'yes'\n  X11Forwarding: 'yes'\n"
          got: "# yamllint disable rule:indentation rule:line-length\n# Debian-10\n---\nmap_jinja:\n  config_get_roo...td: 'no'\n  Subsystem: sftp /usr/lib/openssh/sftp-server\n  UsePAM: 'yes'\n  X11Forwarding: 'yes'\n"
     
     (compared using ==)
     
     Diff:
     
     @@ -10,11 +10,12 @@
        absent_dsa_keys: false
        absent_ecdsa_keys: false
        absent_ed25519_keys: false
     -  absent_rsa_keys: true
     +  absent_rsa_keys: false
        auth:
          joe-non-valid-ssh-key:
          - comment: obsolete key - removed
            enc: ssh-rsa
     +      present: false
            source: salt://ssh_keys/joe.no-valid.pub
            user: joe
          joe-valid-ssh-key-desktop:
     @@ -22,6 +23,12 @@
            enc: ssh-rsa
            present: true
            source: salt://ssh_keys/joe.desktop.pub
     +      user: joe
     +    joe-valid-ssh-key-notebook:
     +    - comment: main key - notebook
     +      enc: ssh-rsa
     +      present: true
     +      source: salt://ssh_keys/joe.netbook.pub
            user: joe
        auth_map:
          personal_keys:
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


