### PR TITLE
fix(libmatchers): python client API can use `config.get` options

### DIFF
--- a/openssh/libmatchers.jinja
+++ b/openssh/libmatchers.jinja
@@ -162,7 +162,7 @@
 {%-     endif %}
 
 {#-     Add `merge:` option to `salt["config.get"]` if configured #}
-{%-     if cli in ["minion", "local"] and parsed.query_method == "config.get" and config_get_strategy %}
+{%-     if cli not in ["ssh", "unknown"] and parsed.query_method == "config.get" and config_get_strategy %}
 {%-       set query_opts = {
             "merge": config_get_strategy,
             "delimiter": parsed.query_delimiter,
@@ -175,8 +175,8 @@
             ~ "'"
           ) %}
 {%-     else %}
-{%-       if cli not in ["minion", "local"] %}
-{%-         do salt["log.error"](
+{%-       if cli in ["ssh", "unknown"] %}
+{%-         do salt["log.warning"](
               log_prefix
               ~ "the 'delimiter' and 'merge' options of 'config.get' are skipped when the salt command type is '"
               ~ cli

--- a/openssh/libsaltcli.jinja
+++ b/openssh/libsaltcli.jinja
@@ -10,6 +10,8 @@
 {%-   set cli = 'minion' %}
 {%- elif opts_cli == 'salt-call' %}
 {%-   set cli = 'ssh' if opts_masteropts_cli in ('salt-ssh', 'salt-master') else 'local' %}
+{%- elif opts_cli %}
+{%-   set cli = 'api' %}
 {%- else %}
 {%-   set cli = 'unknown' %}
 {%- endif %}


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

Fixes #203

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

fix(libmatchers): python client API can use `config.get` options

Only `salt-ssh` can't use them actually.

* openssh/libsaltcli.jinja: detect non empty `opts['__cli']` as `api`.

* openssh/libmatchers.jinja: only `ssh` and `unknown` can't use
  `config.get` options `merge` and `delimiter`.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

I created

- a simple `salt://foo/test.sls`
  ``` sls
  {%- set tplroot = tpldir.split('/')[0] %}
  {%- from tplroot ~ "/map.jinja" import mapdata with context %}
  
  do-nothing:
    test.nop:
      - name: {{ mapdata | yaml }}
  ```
- a single `salt://foo/parameters/defaults`

``` yaml
values:
  foo: 'bar'
```

With the following `test-libsaltcli` script:

``` python
#!/usr/bin/python3

import logging
# The new log level for `config.get` options is warning
# Use `logging.INFO` to have some context
logging.basicConfig(level=logging.INFO,
                    handlers=[logging.StreamHandler()])

import salt.client
caller = salt.client.Caller()
caller.cmd('state.apply', 'foo.test')
```

Here is the output I got when running the `test-libsaltcli` script:
- <details><summary>before this PR</summary>

  ```# ./test-libsaltcli 
  INFO:salt.state:Loading fresh modules for state activity
  INFO:salt.fileclient:Fetching file from saltenv 'base', ** done ** 'foo/libmatchers.jinja'
  INFO:salt.fileclient:Fetching file from saltenv 'base', ** done ** 'foo/libsaltcli.jinja'
  ERROR:salt.loaded.int.module.logmod:map.jinja configuration: the 'delimiter' and 'merge' options of 'config.get' are skipped when the salt command type is 'unknown'
  ERROR:salt.loaded.int.module.logmod:map.jinja: the 'delimiter' and 'merge' options of 'config.get' are skipped when the salt command type is 'unknown'
  ERROR:salt.loaded.int.module.logmod:map.jinja: the 'delimiter' and 'merge' options of 'config.get' are skipped when the salt command type is 'unknown'
  ERROR:salt.loaded.int.module.logmod:map.jinja: the 'delimiter' and 'merge' options of 'config.get' are skipped when the salt command type is 'unknown'
  ERROR:salt.loaded.int.module.logmod:map.jinja: the 'delimiter' and 'merge' options of 'config.get' are skipped when the salt command type is 'unknown'
  ERROR:salt.loaded.int.module.logmod:map.jinja: the 'delimiter' and 'merge' options of 'config.get' are skipped when the salt command type is 'unknown'
  ERROR:salt.loaded.int.module.logmod:map.jinja: the 'delimiter' and 'merge' options of 'config.get' are skipped when the salt command type is 'unknown'
  ERROR:salt.loaded.int.module.logmod:map.jinja: the 'delimiter' and 'merge' options of 'config.get' are skipped when the salt command type is 'unknown'
  ERROR:salt.loaded.int.module.logmod:map.jinja: the 'delimiter' and 'merge' options of 'config.get' are skipped when the salt command type is 'unknown'
  INFO:salt.state:Running state [do-nothing] at time 14:35:01.961919
  INFO:salt.state:Executing state test.nop for [do-nothing]
  INFO:salt.state:Success!
  INFO:salt.state:Completed state [do-nothing] at time 14:35:01.962937 (duration_in_ms=1.018)
  ```
  </details>
- <details><summary>after this PR</summary>

  ```# ./test-libsaltcli 
  INFO:salt.state:Loading fresh modules for state activity
  INFO:salt.fileclient:Fetching file from saltenv 'base', ** done ** 'foo/libmatchers.jinja'
  INFO:salt.fileclient:Fetching file from saltenv 'base', ** done ** 'foo/libsaltcli.jinja'
  INFO:salt.state:Running state [do-nothing] at time 14:36:08.336434
  INFO:salt.state:Executing state test.nop for [do-nothing]
  INFO:salt.state:Success!
  INFO:salt.state:Completed state [do-nothing] at time 14:36:08.337350 (duration_in_ms=0.916)
  ```
  </details>

I found the proper `DEBUG:salt.loaded.int.module.logmod:[libsaltcli] the salt command type has been identified to be: api` log.

<details><summary>Complete log log with <code>level=logging.DEBUG</code> </summary>

```DEBUG:salt.utils.decorators.jinja:Marking 'set_dict_key_value' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'update_dict_key_value' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'append_dict_key_value' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'extend_dict_key_value' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'to_bytes' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'to_num' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'str_to_num' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'is_hex' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'random_str' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'contains_whitespace' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'check_whitelist_blacklist' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'to_snake_case' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'to_camelcase' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'compare_dicts' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'compare_lists' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'json_encode_dict' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'json_decode_dict' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'json_encode_list' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'json_decode_list' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'exactly_n_true' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'exactly_one_true' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'traverse' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'substring_in_list' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'is_list' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'is_iter' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'sorted_ignorecase' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'mysql_to_dict' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'json_query' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'which' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'path_join' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'is_empty' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'is_text_file' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'is_bin_file' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'list_files' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'is_ip' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'is_ipv4' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'is_ipv6' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'ipv4' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'ipv6' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'ipaddr' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'ip_host' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'network_hosts' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'network_size' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'gen_mac' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'mac_str_to_bytes' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'dns_check' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'filter_by_networks' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'get_uid' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'base64_encode' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'base64_decode' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'md5' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'sha1' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'sha256' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'sha512' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'hmac' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'hmac_compute' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'random_hash' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'rand_str' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'file_hashsum' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'http_query' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'strftime' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'date_format' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'raise' as a jinja global
DEBUG:salt.utils.decorators.jinja:Marking 'match' as a jinja test
DEBUG:salt.utils.decorators.jinja:Marking 'equalto' as a jinja test
DEBUG:salt.utils.decorators.jinja:Marking 'skip' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'sequence' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'to_bool' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'indent' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'tojson' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'quote' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'regex_escape' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'regex_search' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'regex_match' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'regex_replace' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'uuid' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'unique' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'min' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'max' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'avg' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'union' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'intersect' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'difference' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'symmetric_difference' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'method_call' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'yaml_dquote' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'yaml_squote' as a jinja filter
DEBUG:salt.utils.decorators.jinja:Marking 'yaml_encode' as a jinja filter
DEBUG:salt.config:Reading configuration from /etc/salt/minion
DEBUG:salt.config:Including configuration from '/etc/salt/minion.d/_schedule.conf'
DEBUG:salt.config:Reading configuration from /etc/salt/minion.d/_schedule.conf
DEBUG:salt.config:Including configuration from '/etc/salt/minion.d/beacons.conf'
DEBUG:salt.config:Reading configuration from /etc/salt/minion.d/beacons.conf
DEBUG:salt.config:Including configuration from '/etc/salt/minion.d/engine.conf'
DEBUG:salt.config:Reading configuration from /etc/salt/minion.d/engine.conf
DEBUG:salt.config:Including configuration from '/etc/salt/minion.d/f_defaults.conf'
DEBUG:salt.config:Reading configuration from /etc/salt/minion.d/f_defaults.conf
DEBUG:salt.config:Including configuration from '/etc/salt/minion.d/reactor.conf'
DEBUG:salt.config:Reading configuration from /etc/salt/minion.d/reactor.conf
DEBUG:salt.config:Using cached minion ID from /etc/salt/minion_id: salt-alcali_196_salt_master_0
DEBUG:salt.loader:Grains refresh requested. Refreshing grains.
DEBUG:salt.config:Reading configuration from /etc/salt/minion
DEBUG:salt.config:Including configuration from '/etc/salt/minion.d/_schedule.conf'
DEBUG:salt.config:Reading configuration from /etc/salt/minion.d/_schedule.conf
DEBUG:salt.config:Including configuration from '/etc/salt/minion.d/beacons.conf'
DEBUG:salt.config:Reading configuration from /etc/salt/minion.d/beacons.conf
DEBUG:salt.config:Including configuration from '/etc/salt/minion.d/engine.conf'
DEBUG:salt.config:Reading configuration from /etc/salt/minion.d/engine.conf
DEBUG:salt.config:Including configuration from '/etc/salt/minion.d/f_defaults.conf'
DEBUG:salt.config:Reading configuration from /etc/salt/minion.d/f_defaults.conf
DEBUG:salt.config:Including configuration from '/etc/salt/minion.d/reactor.conf'
DEBUG:salt.config:Reading configuration from /etc/salt/minion.d/reactor.conf
DEBUG:salt.utils.entrypoints:Using importlib_metadata to load entry points
DEBUG:salt.loader.lazy:Override  __utils__: <module 'salt.loaded.int.grains.zfs' from '/usr/lib/python3/dist-packages/salt/grains/zfs.py'>
DEBUG:salt.modules.network:Unable to resolve address fe80::c0ff:fea8:6b: [Errno 1] Unknown host
DEBUG:salt.modules.network:Elapsed time getting FQDNs: 0.01723313331604004 seconds
DEBUG:salt.loaded.int.grains.extra:Loading static grains from /etc/salt/grains
DEBUG:salt.utils.lazy:LazyLoaded zfs.is_supported
DEBUG:salt.minion:Connecting to master. Attempt 1 of 1
DEBUG:salt.utils.network:"salt-alcali_196_salt_master_0" Not an IP address? Assuming it is a hostname.
DEBUG:salt.minion:Master URI: tcp://192.168.0.107:4506
DEBUG:salt.crypt:Initializing new AsyncAuth for ('/etc/salt/pki/minion', 'salt-alcali_196_salt_master_0', 'tcp://192.168.0.107:4506')
DEBUG:salt.transport.zeromq:Generated random reconnect delay between '1000ms' and '11000ms' (10248)
DEBUG:salt.transport.zeromq:Setting zmq_reconnect_ivl to '10248ms'
DEBUG:salt.transport.zeromq:Setting zmq_reconnect_ivl_max to '11000ms'
DEBUG:salt.transport.zeromq:Connecting the Minion to the Master URI (for the return server): tcp://192.168.0.107:4506
DEBUG:salt.transport.zeromq:Trying to connect to: tcp://192.168.0.107:4506
DEBUG:salt.crypt:salt.crypt.get_rsa_pub_key: Loading public key
DEBUG:salt.crypt:Decrypting the current master AES key
DEBUG:salt.crypt:salt.crypt.get_rsa_key: Loading private key
DEBUG:salt.crypt:salt.crypt._get_key_with_evict: Loading private key
DEBUG:salt.crypt:Loaded minion key: /etc/salt/pki/minion/minion.pem
DEBUG:salt.crypt:salt.crypt.get_rsa_pub_key: Loading public key
DEBUG:salt.transport.zeromq:Closing AsyncZeroMQReqChannel instance
DEBUG:salt.transport.zeromq:Connecting the Minion to the Master publish port, using the URI: tcp://192.168.0.107:4505
DEBUG:salt.crypt:salt.crypt.get_rsa_key: Loading private key
DEBUG:salt.crypt:Loaded minion key: /etc/salt/pki/minion/minion.pem
DEBUG:salt.pillar:Determining pillar cache
DEBUG:salt.crypt:Initializing new AsyncAuth for ('/etc/salt/pki/minion', 'salt-alcali_196_salt_master_0', 'tcp://192.168.0.107:4506')
DEBUG:salt.transport.zeromq:Connecting the Minion to the Master URI (for the return server): tcp://192.168.0.107:4506
DEBUG:salt.transport.zeromq:Trying to connect to: tcp://192.168.0.107:4506
DEBUG:salt.crypt:salt.crypt.get_rsa_key: Loading private key
DEBUG:salt.crypt:Loaded minion key: /etc/salt/pki/minion/minion.pem
DEBUG:salt.transport.zeromq:Closing AsyncZeroMQReqChannel instance
DEBUG:salt.utils.entrypoints:Using importlib_metadata to load entry points
DEBUG:salt.utils.lazy:LazyLoaded jinja.render
DEBUG:salt.utils.lazy:LazyLoaded yaml.render
DEBUG:salt.utils.lazy:LazyLoaded state.apply
DEBUG:salt.utils.lazy:LazyLoaded saltutil.is_running
DEBUG:salt.loader.lazy:Override  __grains__: <module 'salt.loaded.int.module.grains' from '/usr/lib/python3/dist-packages/salt/modules/grains.py'>
DEBUG:salt.utils.lazy:LazyLoaded grains.get
DEBUG:salt.utils.lazy:LazyLoaded config.get
DEBUG:salt.crypt:Initializing new AsyncAuth for ('/etc/salt/pki/minion', 'salt-alcali_196_salt_master_0', 'tcp://192.168.0.107:4506')
DEBUG:salt.transport.zeromq:Connecting the Minion to the Master URI (for the return server): tcp://192.168.0.107:4506
DEBUG:salt.transport.zeromq:Trying to connect to: tcp://192.168.0.107:4506
DEBUG:salt.state:Gathering pillar data for state run
DEBUG:salt.pillar:Determining pillar cache
DEBUG:salt.crypt:Initializing new AsyncAuth for ('/etc/salt/pki/minion', 'salt-alcali_196_salt_master_0', 'tcp://192.168.0.107:4506')
DEBUG:salt.transport.zeromq:Connecting the Minion to the Master URI (for the return server): tcp://192.168.0.107:4506
DEBUG:salt.transport.zeromq:Trying to connect to: tcp://192.168.0.107:4506
DEBUG:salt.crypt:salt.crypt.get_rsa_key: Loading private key
DEBUG:salt.crypt:Loaded minion key: /etc/salt/pki/minion/minion.pem
DEBUG:salt.transport.zeromq:Closing AsyncZeroMQReqChannel instance
DEBUG:salt.state:Finished gathering pillar data for state run
INFO:salt.state:Loading fresh modules for state activity
DEBUG:salt.utils.lazy:LazyLoaded jinja.render
DEBUG:salt.utils.lazy:LazyLoaded yaml.render
DEBUG:salt.fileclient:In saltenv 'base', looking at rel_path 'foo/test.sls' to resolve 'salt://foo/test.sls'
DEBUG:salt.fileclient:In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/foo/test.sls' to resolve 'salt://foo/test.sls'
DEBUG:salt.template:compile template: /var/cache/salt/minion/files/base/foo/test.sls
DEBUG:salt.utils.jinja:Jinja search path: ['/var/cache/salt/minion/files/base']
DEBUG:salt.crypt:Initializing new AsyncAuth for ('/etc/salt/pki/minion', 'salt-alcali_196_salt_master_0', 'tcp://192.168.0.107:4506')
DEBUG:salt.transport.zeromq:Connecting the Minion to the Master URI (for the return server): tcp://192.168.0.107:4506
DEBUG:salt.transport.zeromq:Trying to connect to: tcp://192.168.0.107:4506
DEBUG:salt.fileclient:In saltenv 'base', looking at rel_path 'foo/map.jinja' to resolve 'salt://foo/map.jinja'
DEBUG:salt.fileclient:In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/foo/map.jinja' to resolve 'salt://foo/map.jinja'
DEBUG:salt.fileclient:In saltenv 'base', looking at rel_path 'foo/libmapstack.jinja' to resolve 'salt://foo/libmapstack.jinja'
DEBUG:salt.fileclient:In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/foo/libmapstack.jinja' to resolve 'salt://foo/libmapstack.jinja'
DEBUG:salt.fileclient:In saltenv 'base', looking at rel_path 'foo/libmatchers.jinja' to resolve 'salt://foo/libmatchers.jinja'
DEBUG:salt.fileclient:In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/foo/libmatchers.jinja' to resolve 'salt://foo/libmatchers.jinja'
DEBUG:salt.fileclient:In saltenv 'base', looking at rel_path 'foo/libsaltcli.jinja' to resolve 'salt://foo/libsaltcli.jinja'
DEBUG:salt.fileclient:In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/foo/libsaltcli.jinja' to resolve 'salt://foo/libsaltcli.jinja'
DEBUG:salt.utils.lazy:LazyLoaded log.debug
DEBUG:salt.loaded.int.module.logmod:[libsaltcli] the salt command type has been identified to be: api
DEBUG:salt.utils.lazy:LazyLoaded config.get
DEBUG:salt.loaded.int.module.logmod:map.jinja configuration: process matcher: 'map_jinja.yaml'
DEBUG:salt.loaded.int.module.logmod:map.jinja configuration: use built-in defaults for matcher:
    option: null
    query: map_jinja.yaml
    query_delimiter: ':'
    query_method: config.get
    type: F
DEBUG:salt.loaded.int.module.logmod:map.jinja configuration: lookup 'map_jinja.yaml' with 'config.get'
DEBUG:salt.loaded.int.module.logmod:map.jinja configuration: parsed matchers:
    - option: null
      query: map_jinja.yaml
      query_delimiter: ':'
      query_method: config.get
      type: F
      value: []
DEBUG:salt.loaded.int.module.logmod:map.jinja configuration: built-in configuration:
values:
  sources:
  - Y:G@osarch
  - Y:G@os_family
  - Y:G@os
  - Y:G@osfinger
  - C@foo:lookup
  - C@foo
  - Y:G@id
DEBUG:salt.loaded.int.module.logmod:map.jinja configuration: load configuration values from parameters/map_jinja.yaml
DEBUG:salt.fileclient:Could not find file 'salt://parameters/map_jinja.yaml' in saltenv 'base'
DEBUG:salt.loaded.int.module.logmod:map.jinja configuration: load configuration values from parameters/map_jinja.yaml.jinja
DEBUG:salt.fileclient:Could not find file 'salt://parameters/map_jinja.yaml.jinja' in saltenv 'base'
DEBUG:salt.loaded.int.module.logmod:map.jinja configuration: load configuration values from foo/parameters/map_jinja.yaml
DEBUG:salt.fileclient:Could not find file 'salt://foo/parameters/map_jinja.yaml' in saltenv 'base'
DEBUG:salt.loaded.int.module.logmod:map.jinja configuration: load configuration values from foo/parameters/map_jinja.yaml.jinja
DEBUG:salt.fileclient:Could not find file 'salt://foo/parameters/map_jinja.yaml.jinja' in saltenv 'base'
DEBUG:salt.loaded.int.module.logmod:map.jinja configuration: final configuration values:
values:
  sources:
  - Y:G@osarch
  - Y:G@os_family
  - Y:G@os
  - Y:G@osfinger
  - C@foo:lookup
  - C@foo
  - Y:G@id
DEBUG:salt.loaded.int.module.logmod:map.jinja: load parameters from sources:
- Y:G@osarch
- Y:G@os_family
- Y:G@os
- Y:G@osfinger
- C@foo:lookup
- C@foo
- Y:G@id
DEBUG:salt.loaded.int.module.logmod:map.jinja: process matcher: 'defaults.yaml'
DEBUG:salt.loaded.int.module.logmod:map.jinja: use built-in defaults for matcher:
    option: null
    query: defaults.yaml
    query_delimiter: ':'
    query_method: config.get
    type: F
DEBUG:salt.loaded.int.module.logmod:map.jinja: lookup 'defaults.yaml' with 'config.get'
DEBUG:salt.loaded.int.module.logmod:map.jinja: process matcher: 'Y:G@osarch'
DEBUG:salt.loaded.int.module.logmod:map.jinja: parse matcher: 'Y:G@osarch'
DEBUG:salt.loaded.int.module.logmod:map.jinja: parse as 2 metadata matcher:
    option: G
    query: osarch
    query_delimiter: ':'
    type: Y
DEBUG:salt.loaded.int.module.logmod:map.jinja: lookup 'osarch' with 'grains.get'
DEBUG:salt.loader.lazy:Override  __grains__: <module 'salt.loaded.int.module.grains' from '/usr/lib/python3/dist-packages/salt/modules/grains.py'>
DEBUG:salt.utils.lazy:LazyLoaded grains.get
DEBUG:salt.loaded.int.module.logmod:map.jinja: process matcher: 'Y:G@os_family'
DEBUG:salt.loaded.int.module.logmod:map.jinja: parse matcher: 'Y:G@os_family'
DEBUG:salt.loaded.int.module.logmod:map.jinja: parse as 2 metadata matcher:
    option: G
    query: os_family
    query_delimiter: ':'
    type: Y
DEBUG:salt.loaded.int.module.logmod:map.jinja: lookup 'os_family' with 'grains.get'
DEBUG:salt.loaded.int.module.logmod:map.jinja: process matcher: 'Y:G@os'
DEBUG:salt.loaded.int.module.logmod:map.jinja: parse matcher: 'Y:G@os'
DEBUG:salt.loaded.int.module.logmod:map.jinja: parse as 2 metadata matcher:
    option: G
    query: os
    query_delimiter: ':'
    type: Y
DEBUG:salt.loaded.int.module.logmod:map.jinja: lookup 'os' with 'grains.get'
DEBUG:salt.loaded.int.module.logmod:map.jinja: process matcher: 'Y:G@osfinger'
DEBUG:salt.loaded.int.module.logmod:map.jinja: parse matcher: 'Y:G@osfinger'
DEBUG:salt.loaded.int.module.logmod:map.jinja: parse as 2 metadata matcher:
    option: G
    query: osfinger
    query_delimiter: ':'
    type: Y
DEBUG:salt.loaded.int.module.logmod:map.jinja: lookup 'osfinger' with 'grains.get'
DEBUG:salt.loaded.int.module.logmod:map.jinja: process matcher: 'C@foo:lookup'
DEBUG:salt.loaded.int.module.logmod:map.jinja: parse matcher: 'C@foo:lookup'
DEBUG:salt.loaded.int.module.logmod:map.jinja: parse as 1 metadata matcher:
    option: C
    query: foo:lookup
    query_delimiter: ':'
    type: C
DEBUG:salt.loaded.int.module.logmod:map.jinja: lookup 'foo:lookup' with 'config.get'
DEBUG:salt.loaded.int.module.logmod:map.jinja: process matcher: 'C@foo'
DEBUG:salt.loaded.int.module.logmod:map.jinja: parse matcher: 'C@foo'
DEBUG:salt.loaded.int.module.logmod:map.jinja: parse as 1 metadata matcher:
    option: C
    query: foo
    query_delimiter: ':'
    type: C
DEBUG:salt.loaded.int.module.logmod:map.jinja: lookup 'foo' with 'config.get'
DEBUG:salt.loaded.int.module.logmod:map.jinja: process matcher: 'Y:G@id'
DEBUG:salt.loaded.int.module.logmod:map.jinja: parse matcher: 'Y:G@id'
DEBUG:salt.loaded.int.module.logmod:map.jinja: parse as 2 metadata matcher:
    option: G
    query: id
    query_delimiter: ':'
    type: Y
DEBUG:salt.loaded.int.module.logmod:map.jinja: lookup 'id' with 'grains.get'
DEBUG:salt.loaded.int.module.logmod:map.jinja: parsed matchers:
    - option: null
      query: defaults.yaml
      query_delimiter: ':'
      query_method: config.get
      type: F
      value: []
    - option: G
      query: osarch
      query_delimiter: ':'
      query_method: grains.get
      type: Y
      value: amd64
    - option: G
      query: os_family
      query_delimiter: ':'
      query_method: grains.get
      type: Y
      value: Debian
    - option: G
      query: os
      query_delimiter: ':'
      query_method: grains.get
      type: Y
      value: Debian
    - option: G
      query: osfinger
      query_delimiter: ':'
      query_method: grains.get
      type: Y
      value: Debian-11
    - option: C
      query: foo:lookup
      query_delimiter: ':'
      query_method: config.get
      type: C
      value: []
    - option: C
      query: foo
      query_delimiter: ':'
      query_method: config.get
      type: C
      value: []
    - option: G
      query: id
      query_delimiter: ':'
      query_method: grains.get
      type: Y
      value: salt-alcali_196_salt_master_0
DEBUG:salt.loaded.int.module.logmod:map.jinja: built-in configuration:
values: {}
DEBUG:salt.loaded.int.module.logmod:map.jinja: load configuration values from foo/parameters/defaults.yaml
DEBUG:salt.fileclient:In saltenv 'base', looking at rel_path 'foo/parameters/defaults.yaml' to resolve 'salt://foo/parameters/defaults.yaml'
DEBUG:salt.fileclient:In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/foo/parameters/defaults.yaml' to resolve 'salt://foo/parameters/defaults.yaml'
DEBUG:salt.loaded.int.module.logmod:map.jinja: loaded configuration values from foo/parameters/defaults.yaml:
values:
  foo: bar
DEBUG:salt.utils.lazy:LazyLoaded slsutil.merge
DEBUG:salt.loaded.int.module.logmod:map.jinja: merged configuration values from foo/parameters/defaults.yaml, merge: strategy='smart', merge_lists='False':
values:
  foo: bar
DEBUG:salt.loaded.int.module.logmod:map.jinja: load configuration values from foo/parameters/defaults.yaml.jinja
DEBUG:salt.fileclient:Could not find file 'salt://foo/parameters/defaults.yaml.jinja' in saltenv 'base'
DEBUG:salt.loaded.int.module.logmod:map.jinja: load configuration values from foo/parameters/osarch/amd64.yaml
DEBUG:salt.fileclient:Could not find file 'salt://foo/parameters/osarch/amd64.yaml' in saltenv 'base'
DEBUG:salt.loaded.int.module.logmod:map.jinja: load configuration values from foo/parameters/osarch/amd64.yaml.jinja
DEBUG:salt.fileclient:Could not find file 'salt://foo/parameters/osarch/amd64.yaml.jinja' in saltenv 'base'
DEBUG:salt.loaded.int.module.logmod:map.jinja: load configuration values from foo/parameters/os_family/Debian.yaml
DEBUG:salt.fileclient:Could not find file 'salt://foo/parameters/os_family/Debian.yaml' in saltenv 'base'
DEBUG:salt.loaded.int.module.logmod:map.jinja: load configuration values from foo/parameters/os_family/Debian.yaml.jinja
DEBUG:salt.fileclient:Could not find file 'salt://foo/parameters/os_family/Debian.yaml.jinja' in saltenv 'base'
DEBUG:salt.loaded.int.module.logmod:map.jinja: load configuration values from foo/parameters/os/Debian.yaml
DEBUG:salt.fileclient:Could not find file 'salt://foo/parameters/os/Debian.yaml' in saltenv 'base'
DEBUG:salt.loaded.int.module.logmod:map.jinja: load configuration values from foo/parameters/os/Debian.yaml.jinja
DEBUG:salt.fileclient:Could not find file 'salt://foo/parameters/os/Debian.yaml.jinja' in saltenv 'base'
DEBUG:salt.loaded.int.module.logmod:map.jinja: load configuration values from foo/parameters/osfinger/Debian-11.yaml
DEBUG:salt.fileclient:Could not find file 'salt://foo/parameters/osfinger/Debian-11.yaml' in saltenv 'base'
DEBUG:salt.loaded.int.module.logmod:map.jinja: load configuration values from foo/parameters/osfinger/Debian-11.yaml.jinja
DEBUG:salt.fileclient:Could not find file 'salt://foo/parameters/osfinger/Debian-11.yaml.jinja' in saltenv 'base'
DEBUG:salt.loaded.int.module.logmod:map.jinja: merge 'foo:lookup' retrieved with 'config.get', merge: strategy='smart', lists='False':
{}
DEBUG:salt.loaded.int.module.logmod:map.jinja: merge 'foo' retrieved with 'config.get', merge: strategy='smart', lists='False':
{}
DEBUG:salt.loaded.int.module.logmod:map.jinja: load configuration values from foo/parameters/id/salt-alcali_196_salt_master_0.yaml
DEBUG:salt.fileclient:Could not find file 'salt://foo/parameters/id/salt-alcali_196_salt_master_0.yaml' in saltenv 'base'
DEBUG:salt.loaded.int.module.logmod:map.jinja: load configuration values from foo/parameters/id/salt-alcali_196_salt_master_0.yaml.jinja
DEBUG:salt.fileclient:Could not find file 'salt://foo/parameters/id/salt-alcali_196_salt_master_0.yaml.jinja' in saltenv 'base'
DEBUG:salt.loaded.int.module.logmod:map.jinja: final configuration values:
values:
  foo: bar
DEBUG:salt.loaded.int.module.logmod:map.jinja: save parameters in variable 'mapdata'
DEBUG:salt.loaded.int.module.logmod:map.jinja: post-processing of 'mapdata'
DEBUG:salt.fileclient:Could not find file 'salt://foo/post-map.jinja' in saltenv 'base'
PROFILE:salt.template:Time (in seconds) to render '/var/cache/salt/minion/files/base/foo/test.sls' using 'jinja' renderer: 0.30371975898742676
DEBUG:salt.loaded.int.render.yaml:Results of YAML rendering: 
OrderedDict([('do-nothing', OrderedDict([('test.nop', [OrderedDict([('name', OrderedDict([('foo', 'bar'), ('map_jinja', OrderedDict([('sources', ['Y:G@osarch', 'Y:G@os_family', 'Y:G@os', 'Y:G@osfinger', 'C@foo:lookup', 'C@foo', 'Y:G@id'])]))]))])])]))])
PROFILE:salt.template:Time (in seconds) to render '/var/cache/salt/minion/files/base/foo/test.sls' using 'yaml' renderer: 0.00039649009704589844
DEBUG:salt.utils.lazy:LazyLoaded test.nop
INFO:salt.state:Running state [do-nothing] at time 14:29:48.906731
INFO:salt.state:Executing state test.nop for [do-nothing]
INFO:salt.state:Success!
INFO:salt.state:Completed state [do-nothing] at time 14:29:48.907715 (duration_in_ms=0.984)
DEBUG:salt.state:File /var/cache/salt/minion/accumulator/139704432781008 does not exist, no need to cleanup
DEBUG:salt.transport.zeromq:Closing AsyncZeroMQReqChannel instance
DEBUG:salt.utils.lazy:LazyLoaded state.check_result
DEBUG:salt.transport.zeromq:Closing AsyncZeroMQReqChannel instance
```
</details>

Note that running from python directly does not set the `opts[__cli]`, it's only from scripts.

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


