### PR TITLE
ci(config_spec): deal with IP address after minion.id

### DIFF
--- a/test/integration/default/controls/config_spec.rb
+++ b/test/integration/default/controls/config_spec.rb
@@ -10,9 +10,9 @@ root_group =
   end
 
 github_known_host = 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGm[...]'
-gitlab_known_host_re = /gitlab.com,[0-9a-f.:,]* ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABA/
-minion_rsa_known_host = 'minion.id,alias.of.minion.id ssh-rsa [...]'
-minion_ed25519_known_host = 'minion.id,alias.of.minion.id ssh-ed25519 [...]'
+gitlab_known_host_re = /gitlab.com[0-9a-f.:,]* ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABA/
+minion_rsa_known_host = /minion\.id,alias\.of\.minion.id[0-9a-f.:,]* ssh-rsa .+/
+minion_ed25519_known_host = /minion\.id,alias\.of\.minion\.id[0-9a-f.:,]* ssh-ed25519 .+/
 
 control 'openssh configuration' do
   title 'should match desired lines'
@@ -50,7 +50,7 @@ control 'openssh configuration' do
     it { should be_grouped_into root_group }
     its('content') { should include github_known_host }
     its('content') { should match(gitlab_known_host_re) }
-    its('content') { should include minion_rsa_known_host }
-    its('content') { should include minion_ed25519_known_host }
+    its('content') { should match minion_rsa_known_host }
+    its('content') { should match minion_ed25519_known_host }
   end
 end


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [x] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

–

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

The tests did not match `minion.id,alias.of.minion.id,103.253.215.19 ssh-...`. Now they do.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

–

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

```
-----> Starting Test Kitchen (v3.3.1)
-----> Verifying <default-debian-11-master-py3>...
       Loaded default 

Profile:   openssh formula (default)
Version:   (not specified)
Target:    ssh://kitchen@localhost:32771
Target ID: b1a7d006-07df-52d0-bebb-8a4cc5ad15a1

  ✔  openssh._mapdata: `map.jinja` should match the reference file
     ✔  File content should match profile map data exactly
  ✔  openssh configuration: should match desired lines
     ✔  File /etc/ssh/sshd_config is expected to be file
     ✔  File /etc/ssh/sshd_config is expected to be owned by "root"
     ✔  File /etc/ssh/sshd_config is expected to be grouped into "root"
     ✔  File /etc/ssh/sshd_config mode is expected to cmp == "0644"
     ✔  File /etc/ssh/sshd_config content is expected to include "ChallengeResponseAuthentication no"
     ✔  File /etc/ssh/sshd_config content is expected to include "X11Forwarding yes"
     ✔  File /etc/ssh/sshd_config content is expected to include "PrintMotd no"
     ✔  File /etc/ssh/sshd_config content is expected to include "AcceptEnv LANG LC_*"
     ✔  File /etc/ssh/sshd_config content is expected to include "Subsystem sftp /usr/lib/openssh/sftp-server"
     ✔  File /etc/ssh/sshd_config content is expected to include "UsePAM yes"
     ✔  File /etc/ssh/ssh_config is expected to be file
     ✔  File /etc/ssh/ssh_config is expected to be owned by "root"
     ✔  File /etc/ssh/ssh_config is expected to be grouped into "root"
     ✔  File /etc/ssh/ssh_config mode is expected to cmp == "0644"
     ✔  File /etc/ssh/ssh_config content is expected to include "Host *"
     ✔  File /etc/ssh/ssh_config content is expected to include "    GSSAPIAuthentication yes"
     ✔  File /etc/ssh/ssh_config content is expected to include "    HashKnownHosts yes"
     ✔  File /etc/ssh/ssh_config content is expected to include "    SendEnv LANG LC_*"
     ✔  File /etc/ssh/ssh_known_hosts is expected to be file
     ✔  File /etc/ssh/ssh_known_hosts is expected to be owned by "root"
     ✔  File /etc/ssh/ssh_known_hosts is expected to be grouped into "root"
     ✔  File /etc/ssh/ssh_known_hosts mode is expected to cmp == "0644"
     ✔  File /etc/ssh/ssh_known_hosts content is expected to include "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGm[...]"
     ✔  File /etc/ssh/ssh_known_hosts content is expected to match /gitlab.com[0-9a-f.:,]* ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABA/
     ✔  File /etc/ssh/ssh_known_hosts content is expected to match /minion\.id,alias\.of\.minion.id[0-9a-f.:,]* ssh-rsa .+/
     ✔  File /etc/ssh/ssh_known_hosts content is expected to match /minion\.id,alias\.of\.minion\.id[0-9a-f.:,]* ssh-ed25519 .+/
  ✔  openssh package: should be installed
     ✔  System Package openssh-server is expected to be installed
  ✔  openssh service: should be running and enabled
     ✔  Service ssh is expected to be enabled
     ✔  Service ssh is expected to be running


Profile:   InSpec shared resources (share)
Version:   (not specified)
Target:    ssh://kitchen@localhost:32771
Target ID: b1a7d006-07df-52d0-bebb-8a4cc5ad15a1

     No tests executed.

Profile Summary: 4 successful controls, 0 control failures, 0 controls skipped
Test Summary: 30 successful, 0 failures, 0 skipped
       Finished verifying <default-debian-11-master-py3> (0m4.16s).
-----> Test Kitchen is finished. (0m4.99s)
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


